### PR TITLE
Less strict date parsing

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/message/ImapMessage.java
+++ b/src/main/java/com/hubspot/imap/protocol/message/ImapMessage.java
@@ -25,7 +25,7 @@ public interface ImapMessage {
   Message getBody() throws UnfetchedFieldException;
 
   class Builder implements ImapMessage {
-    private static DateTimeFormatter INTERNALDATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MMM-yyyy HH:mm:ss Z");
+    private static DateTimeFormatter INTERNALDATE_FORMATTER = DateTimeFormatter.ofPattern("d-MMM-yyyy HH:mm:ss Z");
 
     private Optional<Set<MessageFlag>> flags = Optional.empty();
     private long messageNumber;
@@ -83,7 +83,7 @@ public interface ImapMessage {
     }
 
     public Builder setInternalDate(String internalDate) {
-      this.internalDate = Optional.of(ZonedDateTime.parse(internalDate, INTERNALDATE_FORMATTER));
+      this.internalDate = Optional.of(ZonedDateTime.parse(internalDate.trim(), INTERNALDATE_FORMATTER));
       return this;
     }
 


### PR DESCRIPTION
The DateTimeFormatter pattern dd-MMM-yyyy, enforces the need for a date of format `03-May-2017`. Sometimes this date is set as ` 3-May-2017` (note the leading whitespace as well). This is a temporary fix to resolve smaller parsing issues. In the future, we may want to have even more flexible Date formatting. 

cc// @zklapow @szabowexler 