### PR TITLE
Migrate some uses of Guava Objects to MoreObjects

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/folder/FolderFlags.java
+++ b/src/main/java/com/hubspot/imap/protocol/folder/FolderFlags.java
@@ -1,11 +1,12 @@
 package com.hubspot.imap.protocol.folder;
 
-import com.google.common.base.Objects;
-
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 public class FolderFlags {
   public enum Flag {
@@ -82,7 +83,7 @@ public class FolderFlags {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("flags", flags)
         .add("permanent", permanent)
         .toString();

--- a/src/main/java/com/hubspot/imap/protocol/message/ImapAddress.java
+++ b/src/main/java/com/hubspot/imap/protocol/message/ImapAddress.java
@@ -1,10 +1,11 @@
 package com.hubspot.imap.protocol.message;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
-
 import java.util.List;
 import java.util.Optional;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 public interface ImapAddress {
   String getPersonal();
@@ -70,7 +71,7 @@ public interface ImapAddress {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .add("personal", personal)
           .add("address", address)
           .toString();

--- a/src/main/java/com/hubspot/imap/protocol/message/ImapMessage.java
+++ b/src/main/java/com/hubspot/imap/protocol/message/ImapMessage.java
@@ -1,15 +1,17 @@
 package com.hubspot.imap.protocol.message;
 
-import com.google.common.base.Objects;
-import com.hubspot.imap.protocol.extension.gmail.GMailLabel;
-import org.apache.james.mime4j.dom.Message;
-
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.james.mime4j.dom.Message;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.hubspot.imap.protocol.extension.gmail.GMailLabel;
 
 public interface ImapMessage {
 
@@ -143,7 +145,7 @@ public interface ImapMessage {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
         .add("flags", flags)
         .add("messageNumber", messageNumber)
         .add("uid", uid)

--- a/src/main/java/com/hubspot/imap/protocol/response/ContinuationResponse.java
+++ b/src/main/java/com/hubspot/imap/protocol/response/ContinuationResponse.java
@@ -1,5 +1,6 @@
 package com.hubspot.imap.protocol.response;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public interface ContinuationResponse {
@@ -23,7 +24,7 @@ public interface ContinuationResponse {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .add("message", message)
           .toString();
     }

--- a/src/main/java/com/hubspot/imap/protocol/response/events/ByeEvent.java
+++ b/src/main/java/com/hubspot/imap/protocol/response/events/ByeEvent.java
@@ -1,6 +1,6 @@
 package com.hubspot.imap.protocol.response.events;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.hubspot.imap.protocol.response.untagged.UntaggedResponse;
 
 public class ByeEvent {
@@ -16,7 +16,7 @@ public class ByeEvent {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("response", response)
         .toString();
   }

--- a/src/main/java/com/hubspot/imap/protocol/response/events/IntEvent.java
+++ b/src/main/java/com/hubspot/imap/protocol/response/events/IntEvent.java
@@ -1,6 +1,6 @@
 package com.hubspot.imap.protocol.response.events;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public abstract class IntEvent {
   private long value;
@@ -15,7 +15,7 @@ public abstract class IntEvent {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("value", value)
         .toString();
   }

--- a/src/main/java/com/hubspot/imap/protocol/response/tagged/TaggedResponse.java
+++ b/src/main/java/com/hubspot/imap/protocol/response/tagged/TaggedResponse.java
@@ -1,10 +1,10 @@
 package com.hubspot.imap.protocol.response.tagged;
 
-import com.google.common.base.Objects;
-import com.hubspot.imap.protocol.response.ResponseCode;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.base.MoreObjects;
+import com.hubspot.imap.protocol.response.ResponseCode;
 
 public interface TaggedResponse {
   String getTag();
@@ -71,7 +71,7 @@ public interface TaggedResponse {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .add("tag", tag)
           .add("message", message)
           .add("untagged", untagged)


### PR DESCRIPTION
This depends on https://github.com/HubSpot/NioImapClient/pull/6 (and has a duplicate commit cause of the base branch situation). It will also make Guava ≥ 19 a requirement for this library.

@zklapow 