### PR TITLE
Return a new response always

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -584,6 +584,7 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
     }
 
     discardSomeReadBytes();
+    responseBuilder = new TaggedResponse.Builder();
     checkpoint(State.START_RESPONSE);
   }
 


### PR DESCRIPTION
This is really dumb, if we send the same response object every time then when the next response calls `set*` on it, we will override the values in the old response. This works out fine if you read the data before sending a new command but otherwise it gets really weird.

@szabowexler @cimmyv 