### PR TITLE
Refactor login

### DIFF
--- a/src/main/java/com/hubspot/imap/ImapClientFactory.java
+++ b/src/main/java/com/hubspot/imap/ImapClientFactory.java
@@ -91,21 +91,21 @@ public class ImapClientFactory implements Closeable {
     bootstrap.channel(channelClass);
   }
 
-  private ImapClient create(String clientName, String userName, String authToken, Optional<ImapConfiguration> newConfig) {
+  private ImapClient create(String clientName, Optional<ImapConfiguration> newConfig) {
     ImapConfiguration finalConfig = newConfig.orElse(configuration);
-    return new ImapClient(finalConfig, bootstrap, promiseExecutorGroup, idleExecutorGroup, clientName, userName, authToken);
+    return new ImapClient(finalConfig, bootstrap, promiseExecutorGroup, idleExecutorGroup, clientName);
   }
 
-  public Future<ImapClient> connect(String userName, String authToken) {
-    return connect(UUID.randomUUID().toString(), userName, authToken, Optional.empty());
+  public Future<ImapClient> connect() {
+    return connect(UUID.randomUUID().toString());
   }
 
-  public Future<ImapClient> connect(String clientName, String userName, String authToken) {
-    return connect(clientName, userName, authToken, Optional.empty());
+  public Future<ImapClient> connect(String clientName) {
+    return connect(clientName, Optional.empty());
   }
 
-  public Future<ImapClient> connect(String clientName, String userName, String authToken, Optional<ImapConfiguration> configuration) {
-    ImapClient client = create(clientName, userName, authToken, configuration);
+  public Future<ImapClient> connect(String clientName, Optional<ImapConfiguration> configuration) {
+    ImapClient client = create(clientName, configuration);
 
     return client.connect();
   }

--- a/src/main/java/com/hubspot/imap/client/ImapClient.java
+++ b/src/main/java/com/hubspot/imap/client/ImapClient.java
@@ -80,8 +80,6 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
 
   private Channel channel;
 
-  private final Promise<TaggedResponse> loginPromise;
-
   private volatile Promise currentCommandPromise;
 
   public ImapClient(ImapConfiguration configuration,
@@ -98,8 +96,6 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
     this.codec = new ImapCodec(clientState);
     this.pendingWriteQueue = new ConcurrentLinkedQueue<>();
     this.connectionClosed = new AtomicBoolean(false);
-
-    loginPromise = promiseExecutor.next().newPromise();
   }
 
   public synchronized Future<ImapClient> connect() {
@@ -139,6 +135,8 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
   }
 
   public Future<TaggedResponse> login(String userName, String authToken) {
+    Promise<TaggedResponse> loginPromise = promiseExecutor.next().newPromise();
+
     Future<TaggedResponse> loginFuture;
     switch (configuration.authType()) {
       case XOAUTH2:
@@ -301,10 +299,6 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
 
   public Future<NoopResponse> noop() {
     return send(ImapCommandType.NOOP);
-  }
-
-  public boolean isLoggedIn() {
-    return loginPromise.isSuccess() && channel.isActive();
   }
 
   public boolean isConnected() {

--- a/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
+++ b/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
@@ -44,8 +44,8 @@ public class BaseGreenMailServerTest {
   }
 
   protected ImapClient getLoggedInClient() throws InterruptedException, ExecutionException {
-    ImapClient client = getClientFactory().connect(currentUser.getEmail(), currentUser.getPassword()).get();
-    client.login().await();
+    ImapClient client = getClientFactory().connect().get();
+    client.login(currentUser.getEmail(), currentUser.getPassword()).await();
 
     return client;
   }

--- a/src/test/java/com/hubspot/imap/ImapClientAuthenticationTest.java
+++ b/src/test/java/com/hubspot/imap/ImapClientAuthenticationTest.java
@@ -20,9 +20,8 @@ public class ImapClientAuthenticationTest extends BaseGreenMailServerTest {
 
   @Test
   public void testGivenInvalidCredentials_doesThrowAuthenticationException() throws Exception {
-    try (ImapClient client = getClientFactory().connect(currentUser.getLogin(), "").get()) {
-      client.login();
-      client.awaitLogin();
+    try (ImapClient client = getClientFactory().connect().get()) {
+      client.login(currentUser.getLogin(), "").await();
     } catch (ExecutionException e) {
       assertThat(e).hasCauseInstanceOf(AuthenticationFailedException.class);
     }

--- a/src/test/java/com/hubspot/imap/ImapMultiServerTest.java
+++ b/src/test/java/com/hubspot/imap/ImapMultiServerTest.java
@@ -36,13 +36,12 @@ public abstract class ImapMultiServerTest {
 
   protected static ImapClient getClientForConfig(TestServerConfig config) throws InterruptedException, ExecutionException {
     ImapClientFactory clientFactory = new ImapClientFactory(config.imapConfiguration());
-    return clientFactory.connect("test", config.user(), config.password()).get();
+    return clientFactory.connect("test").get();
   }
 
   protected static ImapClient getLoggedInClient(TestServerConfig config) throws InterruptedException, ExecutionException, ConnectionClosedException {
     ImapClient client = getClientForConfig(config);
-    client.login();
-    client.awaitLogin();
+    client.login(config.user(), config.password()).await();
 
     return client;
   }


### PR DESCRIPTION
This changes the structure of the IMAP client and factory to not make the user/password built in to the client itself, but to instead be arguments to the login command itself. This also removes things like `awaitLogin` in favor of `client.login(user, pass).await()` which is more idiomatic.

This will make it easier to use the client in an un-authenticated way, or to do things before authentication, like discovering server capabilities.

This is a breaking change.

@szabowexler @cimmyv 