### PR TITLE
Refactor API to use CompletableFuture

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/exceptions/AuthenticationFailedException.java
+++ b/src/main/java/com/hubspot/imap/protocol/exceptions/AuthenticationFailedException.java
@@ -1,10 +1,10 @@
 package com.hubspot.imap.protocol.exceptions;
 
-import com.google.common.io.BaseEncoding;
-
 import java.nio.charset.StandardCharsets;
 
-public class AuthenticationFailedException extends Exception {
+import com.google.common.io.BaseEncoding;
+
+public class AuthenticationFailedException extends RuntimeException {
   private static final BaseEncoding B64 = BaseEncoding.base64();
 
   public AuthenticationFailedException(String message) {

--- a/src/main/java/com/hubspot/imap/utils/NettyCompletableFuture.java
+++ b/src/main/java/com/hubspot/imap/utils/NettyCompletableFuture.java
@@ -1,0 +1,34 @@
+package com.hubspot.imap.utils;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+
+
+public class NettyCompletableFuture<T> extends CompletableFuture<T> implements FutureListener<T> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(NettyCompletableFuture.class);
+
+  private NettyCompletableFuture(Future<T> future) {
+    future.addListener(this);
+  }
+
+  @Override
+  public void operationComplete(Future<T> tFuture) throws Exception {
+    LOGGER.trace("Completing future from thread: {}", Thread.currentThread().getName());
+    if (tFuture.isSuccess()) {
+      complete(tFuture.getNow());
+    } else if (tFuture.isCancelled()) {
+      cancel(true);
+    } else {
+      completeExceptionally(tFuture.cause());
+    }
+  }
+
+  public static <T> CompletableFuture<T> from(Future<T> future) {
+    return new NettyCompletableFuture<>(future);
+  }
+}

--- a/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
+++ b/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
@@ -45,7 +45,7 @@ public class BaseGreenMailServerTest {
 
   protected ImapClient getLoggedInClient() throws InterruptedException, ExecutionException {
     ImapClient client = getClientFactory().connect().get();
-    client.login(currentUser.getEmail(), currentUser.getPassword()).await();
+    client.login(currentUser.getEmail(), currentUser.getPassword()).join();
 
     return client;
   }

--- a/src/test/java/com/hubspot/imap/ConcurrentConnectionTest.java
+++ b/src/test/java/com/hubspot/imap/ConcurrentConnectionTest.java
@@ -21,8 +21,6 @@ import com.hubspot.imap.protocol.response.ResponseCode;
 import com.hubspot.imap.protocol.response.tagged.NoopResponse;
 import com.spotify.futures.CompletableFutures;
 
-import io.netty.util.concurrent.Future;
-
 public class ConcurrentConnectionTest extends BaseGreenMailServerTest {
   private static final int NUM_CONNS = 5;
 
@@ -52,8 +50,7 @@ public class ConcurrentConnectionTest extends BaseGreenMailServerTest {
           int noops = ThreadLocalRandom.current().nextInt(5);
 
           for (int x = 0; x < noops; x++) {
-            Future<NoopResponse> noopResponseFuture = client.noop();
-            NoopResponse response = noopResponseFuture.get();
+            NoopResponse response = client.noop().get();
 
             assertThat(response.getCode()).isEqualTo(ResponseCode.OK);
 

--- a/src/test/java/com/hubspot/imap/ImapClientAuthenticationTest.java
+++ b/src/test/java/com/hubspot/imap/ImapClientAuthenticationTest.java
@@ -2,8 +2,6 @@ package com.hubspot.imap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.ExecutionException;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,8 +19,8 @@ public class ImapClientAuthenticationTest extends BaseGreenMailServerTest {
   @Test
   public void testGivenInvalidCredentials_doesThrowAuthenticationException() throws Exception {
     try (ImapClient client = getClientFactory().connect().get()) {
-      client.login(currentUser.getLogin(), "").await();
-    } catch (ExecutionException e) {
+      client.login(currentUser.getLogin(), "").join();
+    } catch (Exception e) {
       assertThat(e).hasCauseInstanceOf(AuthenticationFailedException.class);
     }
   }

--- a/src/test/java/com/hubspot/imap/ImapMultiServerTest.java
+++ b/src/test/java/com/hubspot/imap/ImapMultiServerTest.java
@@ -41,7 +41,7 @@ public abstract class ImapMultiServerTest {
 
   protected static ImapClient getLoggedInClient(TestServerConfig config) throws InterruptedException, ExecutionException, ConnectionClosedException {
     ImapClient client = getClientForConfig(config);
-    client.login(config.user(), config.password()).await();
+    client.login(config.user(), config.password()).join();
 
     return client;
   }

--- a/src/test/java/com/hubspot/imap/MessageAddListenerTest.java
+++ b/src/test/java/com/hubspot/imap/MessageAddListenerTest.java
@@ -2,6 +2,7 @@ package com.hubspot.imap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -13,8 +14,6 @@ import com.hubspot.imap.client.FolderOpenMode;
 import com.hubspot.imap.client.ImapClient;
 import com.hubspot.imap.protocol.response.ResponseCode;
 import com.hubspot.imap.protocol.response.tagged.OpenResponse;
-
-import io.netty.util.concurrent.Future;
 
 public class MessageAddListenerTest extends BaseGreenMailServerTest {
 
@@ -38,10 +37,11 @@ public class MessageAddListenerTest extends BaseGreenMailServerTest {
 
     client.getState().onMessageAdd((o, n) -> countDownLatch.countDown());
     client.list("", "%");
-    Future<OpenResponse> openFuture = client.open(DEFAULT_FOLDER, FolderOpenMode.READ);
-    openFuture.await(30, TimeUnit.SECONDS);
+    CompletableFuture<OpenResponse> openFuture = client.open(DEFAULT_FOLDER, FolderOpenMode.READ);
+    openFuture.get(30, TimeUnit.SECONDS);
 
-    assertThat(openFuture.isSuccess()).isTrue();
+    assertThat(openFuture.isDone()).isTrue();
+    assertThat(openFuture.isCompletedExceptionally()).isFalse();
     assertThat(openFuture.get().getCode()).isEqualTo(ResponseCode.OK);
     assertThat(countDownLatch.await(1, TimeUnit.SECONDS)).isFalse();
   }
@@ -51,10 +51,11 @@ public class MessageAddListenerTest extends BaseGreenMailServerTest {
     CountDownLatch countDownLatch = new CountDownLatch(1);
 
     client.getState().addOpenEventListener((e) -> countDownLatch.countDown());
-    Future<OpenResponse> openFuture = client.open(DEFAULT_FOLDER, FolderOpenMode.READ);
-    openFuture.await(30, TimeUnit.SECONDS);
+    CompletableFuture<OpenResponse> openFuture = client.open(DEFAULT_FOLDER, FolderOpenMode.READ);
+    openFuture.get(30, TimeUnit.SECONDS);
 
-    assertThat(openFuture.isSuccess()).isTrue();
+    assertThat(openFuture.isDone()).isTrue();
+    assertThat(openFuture.isCompletedExceptionally()).isFalse();
     assertThat(openFuture.get().getCode()).isEqualTo(ResponseCode.OK);
     assertThat(countDownLatch.await(1, TimeUnit.SECONDS)).isTrue();
     assertThat(client.getState().getMessageNumber()).isEqualTo(openFuture.get().getExists());

--- a/src/test/java/com/hubspot/imap/protocol/extension/gmail/GMailFetchExtensionTest.java
+++ b/src/test/java/com/hubspot/imap/protocol/extension/gmail/GMailFetchExtensionTest.java
@@ -3,6 +3,7 @@ package com.hubspot.imap.protocol.extension.gmail;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.Condition;
 import org.junit.Test;
@@ -17,11 +18,10 @@ import com.hubspot.imap.protocol.command.fetch.items.FetchDataItem.FetchDataItem
 import com.hubspot.imap.protocol.message.UnfetchedFieldException;
 import com.hubspot.imap.protocol.response.tagged.FetchResponse;
 
-import io.netty.util.concurrent.Future;
-
 @RunWith(Parameterized.class)
 public class GMailFetchExtensionTest extends ImapMultiServerTest {
-  @Parameter public TestServerConfig testServerConfig;
+  @Parameter
+  public TestServerConfig testServerConfig;
 
   @Test
   public void testGmailFetchExtensions() throws Exception {
@@ -29,7 +29,7 @@ public class GMailFetchExtensionTest extends ImapMultiServerTest {
       return;
     }
 
-    Future<FetchResponse> responseFuture = getLoggedInClient(testServerConfig).fetch(1, Optional.of(2L), FetchDataItemType.X_GM_MSGID, FetchDataItemType.X_GM_THRID);
+    CompletableFuture<FetchResponse> responseFuture = getLoggedInClient(testServerConfig).fetch(1, Optional.of(2L), FetchDataItemType.X_GM_MSGID, FetchDataItemType.X_GM_THRID);
     FetchResponse response = responseFuture.get();
 
     assertThat(response.getMessages()).have(new Condition<>(m -> {

--- a/src/test/java/com/hubspot/imap/protocol/extension/gmail/GMailLabelTest.java
+++ b/src/test/java/com/hubspot/imap/protocol/extension/gmail/GMailLabelTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,8 +23,6 @@ import com.hubspot.imap.protocol.response.ResponseCode;
 import com.hubspot.imap.protocol.response.tagged.FetchResponse;
 import com.hubspot.imap.protocol.response.tagged.OpenResponse;
 
-import io.netty.util.concurrent.Future;
-
 @RunWith(Parameterized.class)
 public class GMailLabelTest extends ImapMultiServerTest {
   @Parameter public TestServerConfig testServerConfig;
@@ -37,11 +36,11 @@ public class GMailLabelTest extends ImapMultiServerTest {
     Set<SystemLabel> systemLabels = Sets.immutableEnumSet(SystemLabel.DRAFTS, SystemLabel.INBOX, SystemLabel.SENT);
 
     try (ImapClient client = getLoggedInClient(testServerConfig)) {
-      Future<OpenResponse> openResponseFuture = client.open(testServerConfig.primaryFolder(), FolderOpenMode.WRITE);
+      CompletableFuture<OpenResponse> openResponseFuture = client.open(testServerConfig.primaryFolder(), FolderOpenMode.WRITE);
       OpenResponse or = openResponseFuture.get();
       assertThat(or.getCode()).isEqualTo(ResponseCode.OK);
 
-      Future<FetchResponse> fetchResponseFuture = client.fetch(1, Optional.empty(), FetchDataItemType.X_GM_LABELS);
+      CompletableFuture<FetchResponse> fetchResponseFuture = client.fetch(1, Optional.empty(), FetchDataItemType.X_GM_LABELS);
       FetchResponse fetchResponse = fetchResponseFuture.get();
 
       Optional<Set<GMailLabel>> allFetchedLabels = fetchResponse.getMessages()


### PR DESCRIPTION
This refactors the whole client API to use `CompletableFuture` instead of returning netty's `Future` directly. This will break basically all usages of the API, but I already bumped the version in 73886ff2a431ad9c3cefc4b8ae9b4775a692c8fd so anything still on `0.2` is safe from this change.

This also removes some of the complexities from login by removing things like `awaitLogin`. Login is now treated (mostly) like any other command.

@cimmyv @szabowexler 