### PR TITLE
Make streaming fetches use CompletableFuture

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
@@ -339,7 +339,7 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
         fetchCommand = ((StreamingFetchCommand) clientState.getCurrentCommand());
       }
 
-      Future<?> future = executorGroup.submit(() -> fetchCommand.handle(message));
+      CompletableFuture<?> future = CompletableFuture.supplyAsync(() -> fetchCommand.handle(message), executorGroup);
 
       untaggedResponses.add(future);
     } else {

--- a/src/main/java/com/hubspot/imap/protocol/response/tagged/StreamingFetchResponse.java
+++ b/src/main/java/com/hubspot/imap/protocol/response/tagged/StreamingFetchResponse.java
@@ -1,16 +1,15 @@
 package com.hubspot.imap.protocol.response.tagged;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-
-import io.netty.util.concurrent.Future;
 
 public interface StreamingFetchResponse<T> extends TaggedResponse {
 
-  List<Future<T>> getMessageConsumerFutures();
+  List<CompletableFuture<T>> getMessageConsumerFutures();
 
   class Builder<T> extends TaggedResponse.Builder implements StreamingFetchResponse {
-    private List<Future<T>> messageConsumerFutures;
+    private List<CompletableFuture<T>> messageConsumerFutures;
 
     public StreamingFetchResponse fromResponse(TaggedResponse response) {
       this.messageConsumerFutures = filterFutures(response);
@@ -23,15 +22,15 @@ public interface StreamingFetchResponse<T> extends TaggedResponse {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> List<Future<T>> filterFutures(TaggedResponse response) {
+    private static <T> List<CompletableFuture<T>> filterFutures(TaggedResponse response) {
       return response.getUntagged().stream()
-          .filter(m -> m instanceof Future)
-          .map(m -> ((Future<T>) m))
+          .filter(m -> m instanceof CompletableFuture)
+          .map(m -> ((CompletableFuture<T>) m))
           .collect(Collectors.toList());
     }
 
     @Override
-    public List<Future<T>> getMessageConsumerFutures() {
+    public List<CompletableFuture<T>> getMessageConsumerFutures() {
       return messageConsumerFutures;
     }
   }

--- a/src/test/java/com/hubspot/imap/client/ImapClientTest.java
+++ b/src/test/java/com/hubspot/imap/client/ImapClientTest.java
@@ -56,8 +56,6 @@ import com.hubspot.imap.protocol.response.tagged.SearchResponse;
 import com.hubspot.imap.protocol.response.tagged.StreamingFetchResponse;
 import com.hubspot.imap.protocol.response.tagged.TaggedResponse;
 
-import io.netty.util.concurrent.Future;
-
 public class ImapClientTest extends BaseGreenMailServerTest {
 
   private ImapClient client;
@@ -270,7 +268,7 @@ public class ImapClientTest extends BaseGreenMailServerTest {
     StreamingFetchResponse<Void> fetchResponse = fetchResponseFuture.get();
 
     int successful = 0;
-    for (Future consumerFuture : fetchResponse.getMessageConsumerFutures()) {
+    for (CompletableFuture consumerFuture : fetchResponse.getMessageConsumerFutures()) {
       consumerFuture.get();
       successful++;
     }


### PR DESCRIPTION
Follow on to #10 this updates the `StreamingFetchCommand` to return `CompletableFuture` as well.

@cimmyv @szabowexler 