### PR TITLE
Add support for STARTTLS

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/command/ImapCommandType.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/ImapCommandType.java
@@ -15,5 +15,7 @@ public enum ImapCommandType {
   STORE,
   SEARCH,
   CAPABILITY,
-  COPY;
+  COPY,
+  STARTTLS
+  ;
 }

--- a/src/main/java/com/hubspot/imap/protocol/exceptions/StartTlsFailedException.java
+++ b/src/main/java/com/hubspot/imap/protocol/exceptions/StartTlsFailedException.java
@@ -1,0 +1,8 @@
+package com.hubspot.imap.protocol.exceptions;
+
+public class StartTlsFailedException extends RuntimeException {
+  public StartTlsFailedException(String message) {
+    super(String.format("Start TLS failed. Response was: %s", message));
+  }
+
+}

--- a/src/test/java/com/hubspot/imap/StartTlsTest.java
+++ b/src/test/java/com/hubspot/imap/StartTlsTest.java
@@ -1,0 +1,33 @@
+package com.hubspot.imap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import com.hubspot.imap.client.ImapClient;
+import com.hubspot.imap.protocol.response.ResponseCode;
+import com.hubspot.imap.protocol.response.tagged.TaggedResponse;
+
+@RunWith(Parameterized.class)
+public class StartTlsTest extends ImapMultiServerTest {
+
+  @Parameter
+  public TestServerConfig testServerConfig;
+
+  @Test
+  public void itDoesSuccesffullyStartTls() throws Exception {
+    try (ImapClient client = getClientForConfig(testServerConfig)) {
+      CompletableFuture<TaggedResponse> tlsResponseFuture = client.startTls();
+      tlsResponseFuture.join();
+      TaggedResponse noopResponse = client.noop().join();
+
+      assertThat(tlsResponseFuture.get().getCode()).isEqualTo(ResponseCode.OK);
+      assertThat(noopResponse.getCode()).isEqualTo(ResponseCode.OK);
+    }
+  }
+}


### PR DESCRIPTION
If the client factory is not using SSL/TLS this makes it possible to issue `STARTTLS` in order to upgrade the plaintext connection to a secure one.

@cimmyv 