### PR TITLE
Fix issues with casting ContinuationResponse to TaggedResponse

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/response/ContinuationResponse.java
+++ b/src/main/java/com/hubspot/imap/protocol/response/ContinuationResponse.java
@@ -3,9 +3,7 @@ package com.hubspot.imap.protocol.response;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-public interface ContinuationResponse {
-  String getMessage();
-
+public interface ContinuationResponse extends ImapResponse {
   class Builder implements ContinuationResponse {
     private String message;
 

--- a/src/main/java/com/hubspot/imap/protocol/response/ImapResponse.java
+++ b/src/main/java/com/hubspot/imap/protocol/response/ImapResponse.java
@@ -1,0 +1,5 @@
+package com.hubspot.imap.protocol.response;
+
+public interface ImapResponse {
+  String getMessage();
+}

--- a/src/main/java/com/hubspot/imap/protocol/response/tagged/TaggedResponse.java
+++ b/src/main/java/com/hubspot/imap/protocol/response/tagged/TaggedResponse.java
@@ -4,11 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.MoreObjects;
+import com.hubspot.imap.protocol.response.ImapResponse;
 import com.hubspot.imap.protocol.response.ResponseCode;
 
-public interface TaggedResponse {
+public interface TaggedResponse extends ImapResponse {
   String getTag();
-  String getMessage();
   List<Object> getUntagged();
   ResponseCode getCode();
 


### PR DESCRIPTION
This defines a single base `ImapResponse` interface and defines a new send method which expects any `ImapResponse` (either a `TaggedResponse` or `ContinuationResponse`) to prevent issues caused when a `ContinuationResponse` is returned but a `TaggedResponse` was expected.