### PR TITLE
Close BufferedBodyParser on channel close

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import com.hubspot.imap.ImapChannelAttrs;
 import com.hubspot.imap.ImapClientConfiguration;
-import com.hubspot.imap.ImapClientFactoryConfiguration;
 import com.hubspot.imap.client.ImapClientState;
 import com.hubspot.imap.protocol.ResponseDecoder.State;
 import com.hubspot.imap.protocol.command.fetch.StreamingFetchCommand;
@@ -170,6 +169,11 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
     FETCH,
     FETCH_BODY,
     RESET;
+  }
+
+  @Override
+  protected void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
+    bufferedBodyParser.close();
   }
 
   @Timed

--- a/src/main/java/com/hubspot/imap/utils/parsers/string/BufferedBodyParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/string/BufferedBodyParser.java
@@ -1,5 +1,7 @@
 package com.hubspot.imap.utils.parsers.string;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
@@ -11,7 +13,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.util.Signal;
 
-public class BufferedBodyParser implements ByteBufParser<Optional<String>> {
+public class BufferedBodyParser implements ByteBufParser<Optional<String>>, Closeable {
 
   private static final Signal REPLAYING_SIGNAL;
   static {
@@ -101,6 +103,14 @@ public class BufferedBodyParser implements ByteBufParser<Optional<String>> {
   private void inc() {
     size++;
     pos++;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (buf != null) {
+      buf.release();
+      buf = null;
+    }
   }
 
   private enum State {


### PR DESCRIPTION
@cimmyv this should cause the buffer to be correctly released when the connection is closed a prevent leaking memory.