### PR TITLE
Use HostAndPort#getHostText instead of HostAndPort#getHost

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
   <properties>
     <project.build.targetJdk>1.8</project.build.targetJdk>
     <netty.version>4.1.8.Final</netty.version>
+    <dep.guava.version>21.0</dep.guava.version>
   </properties>
 
   <profiles>

--- a/src/main/java/com/hubspot/imap/ImapChannelInitializer.java
+++ b/src/main/java/com/hubspot/imap/ImapChannelInitializer.java
@@ -31,7 +31,7 @@ public class ImapChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     if (sslContext != null) {
       channelPipeline.addLast(sslContext.newHandler(socketChannel.alloc(),
-        configuration.hostAndPort().getHostText(),
+        configuration.hostAndPort().getHost(),
         configuration.hostAndPort().getPortOrDefault(993)));
     }
 

--- a/src/main/java/com/hubspot/imap/ImapClientFactory.java
+++ b/src/main/java/com/hubspot/imap/ImapClientFactory.java
@@ -67,7 +67,7 @@ public class ImapClientFactory implements Closeable {
 
     CompletableFuture<ImapClient> connectFuture = new CompletableFuture<>();
 
-    bootstrap.connect(clientConfiguration.hostAndPort().getHostText(), clientConfiguration.hostAndPort().getPort()).addListener(f -> {
+    bootstrap.connect(clientConfiguration.hostAndPort().getHost(), clientConfiguration.hostAndPort().getPort()).addListener(f -> {
       if (f.isSuccess()) {
         Channel channel = ((ChannelFuture) f).channel();
 

--- a/src/main/java/com/hubspot/imap/protocol/extension/gmail/GMailLabel.java
+++ b/src/main/java/com/hubspot/imap/protocol/extension/gmail/GMailLabel.java
@@ -1,10 +1,10 @@
 package com.hubspot.imap.protocol.extension.gmail;
 
-import java.util.Arrays;
-import java.util.Map;
-
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
+
+import java.util.Arrays;
+import java.util.Map;
 
 public interface GMailLabel {
   String getLabel();

--- a/src/test/java/com/hubspot/imap/protocol/extension/gmail/GMailFetchExtensionTest.java
+++ b/src/test/java/com/hubspot/imap/protocol/extension/gmail/GMailFetchExtensionTest.java
@@ -25,7 +25,7 @@ public class GMailFetchExtensionTest extends ImapMultiServerTest {
 
   @Test
   public void testGmailFetchExtensions() throws Exception {
-    if (!testServerConfig.imapConfiguration().hostAndPort().getHostText().contains("gmail")) {
+    if (!testServerConfig.imapConfiguration().hostAndPort().getHost().contains("gmail")) {
       return;
     }
 

--- a/src/test/java/com/hubspot/imap/protocol/extension/gmail/GMailLabelTest.java
+++ b/src/test/java/com/hubspot/imap/protocol/extension/gmail/GMailLabelTest.java
@@ -26,10 +26,10 @@ import com.hubspot.imap.protocol.response.tagged.OpenResponse;
 @RunWith(Parameterized.class)
 public class GMailLabelTest extends ImapMultiServerTest {
   @Parameter public TestServerConfig testServerConfig;
-  
+
   @Test
   public void testCanFetchLabels() throws Exception {
-    if (!testServerConfig.imapConfiguration().hostAndPort().getHostText().contains("gmail")) {
+    if (!testServerConfig.imapConfiguration().hostAndPort().getHost().contains("gmail")) {
       return;
     }
 


### PR DESCRIPTION
`HostAndPost#getHost` replaced `HostAndPort#getHostText` in Guava 20 and `HostAndPort#getHostText` was removed in Guava 22. This PR should have no semantic effect on your code. [Java doc](http://google.github.io/guava/releases/21.0/api/docs/com/google/common/net/HostAndPort.html#getHostText--)

I also had to upgrade to Guava 21 as part of this (20 is the minimum required).

@zklapow 