### PR TITLE
Quote atoms in LOGIN

### DIFF
--- a/src/main/java/com/hubspot/imap/client/ImapClient.java
+++ b/src/main/java/com/hubspot/imap/client/ImapClient.java
@@ -25,6 +25,7 @@ import com.hubspot.imap.protocol.command.ImapCommand;
 import com.hubspot.imap.protocol.command.ImapCommandType;
 import com.hubspot.imap.protocol.command.ListCommand;
 import com.hubspot.imap.protocol.command.OpenCommand;
+import com.hubspot.imap.protocol.command.QuotedImapCommand;
 import com.hubspot.imap.protocol.command.SilentStoreCommand;
 import com.hubspot.imap.protocol.command.StoreCommand.StoreAction;
 import com.hubspot.imap.protocol.command.XOAuth2Command;
@@ -179,7 +180,7 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
   }
 
   private CompletableFuture<? extends ImapResponse> passwordLogin(String userName, String authToken) {
-    return sendRaw(new BaseImapCommand(ImapCommandType.LOGIN, userName, authToken));
+    return sendRaw(new QuotedImapCommand(ImapCommandType.LOGIN, userName, authToken));
   }
 
   private CompletableFuture<? extends ImapResponse> oauthLogin(String userName, String authToken) {

--- a/src/main/java/com/hubspot/imap/protocol/command/QuotedImapCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/QuotedImapCommand.java
@@ -1,0 +1,27 @@
+package com.hubspot.imap.protocol.command;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class QuotedImapCommand extends BaseImapCommand {
+  private static final String QUOTE = "\"";
+
+  public QuotedImapCommand(ImapCommandType type, String... args) {
+    super(type, args);
+  }
+
+  @Override
+  public List<String> getArgs() {
+    return super.getArgs().stream()
+        .map(QuotedImapCommand::quote)
+        .collect(Collectors.toList());
+  }
+
+  private static String quote(String in) {
+    StringBuilder result = new StringBuilder();
+    result.append(QUOTE);
+    result.append(in);
+    result.append(QUOTE);
+    return result.toString();
+  }
+}


### PR DESCRIPTION
This allows either the username or password to contain special chars (excluding double quotes) without issue.

@cimmyv 