### PR TITLE
Allow custom TrustManagerFactory per connection

### DIFF
--- a/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
+++ b/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
@@ -1,5 +1,9 @@
 package com.hubspot.imap;
 
+import java.util.Optional;
+
+import javax.net.ssl.TrustManagerFactory;
+
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
@@ -73,6 +77,11 @@ public interface ImapClientConfigurationIF {
   @Default
   default int maxHeaderCount() {
     return 10000;
+  }
+
+  @Default
+  default Optional<TrustManagerFactory> trustManagerFactory() {
+    return Optional.empty();
   }
 
   enum AuthType {

--- a/src/main/java/com/hubspot/imap/ImapClientFactory.java
+++ b/src/main/java/com/hubspot/imap/ImapClientFactory.java
@@ -1,13 +1,14 @@
 package com.hubspot.imap;
 
 import java.io.Closeable;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.CompletableFuture;
 
 import javax.net.ssl.SSLException;
-import javax.net.ssl.TrustManagerFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.hubspot.imap.client.ImapClient;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -16,11 +17,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.hubspot.imap.client.ImapClient;
 
 public class ImapClientFactory implements Closeable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ImapClientFactory.class);
@@ -33,33 +29,12 @@ public class ImapClientFactory implements Closeable {
   }
 
   public ImapClientFactory(ImapClientFactoryConfiguration configuration) {
-    this(configuration, (KeyStore) null);
-  }
-
-  public ImapClientFactory(ImapClientFactoryConfiguration configuration, TrustManagerFactory trustManagerFactory) {
     this.configuration = configuration;
 
     try {
       sslContext = SslContextBuilder.forClient()
-          .trustManager(trustManagerFactory)
           .build();
-
     } catch (SSLException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public ImapClientFactory(ImapClientFactoryConfiguration configuration, KeyStore keyStore) {
-    this.configuration = configuration;
-
-    try {
-      TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-      trustManagerFactory.init(keyStore);
-
-      sslContext = SslContextBuilder.forClient()
-          .trustManager(trustManagerFactory)
-          .build();
-    } catch (NoSuchAlgorithmException | SSLException | KeyStoreException e) {
       throw new RuntimeException(e);
     }
   }
@@ -69,13 +44,24 @@ public class ImapClientFactory implements Closeable {
   }
 
   public CompletableFuture<ImapClient> connect(String clientName, ImapClientConfiguration clientConfiguration) {
+    SslContext finalSslContext = sslContext;
+    if (clientConfiguration.trustManagerFactory().isPresent()) {
+      try {
+        finalSslContext = SslContextBuilder.forClient()
+            .trustManager(clientConfiguration.trustManagerFactory().get())
+            .build();
+      } catch (SSLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
     Bootstrap bootstrap = new Bootstrap().group(configuration.eventLoopGroup())
         .option(ChannelOption.SO_LINGER, clientConfiguration.soLinger())
         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, clientConfiguration.connectTimeoutMillis())
         .option(ChannelOption.SO_KEEPALIVE, false)
         .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
         .channel(configuration.channelClass())
-        .handler(clientConfiguration.useSsl() ? new ImapChannelInitializer(sslContext, clientConfiguration) : new ImapChannelInitializer(clientConfiguration));
+        .handler(clientConfiguration.useSsl() ? new ImapChannelInitializer(finalSslContext, clientConfiguration) : new ImapChannelInitializer(clientConfiguration));
 
     CompletableFuture<ImapClient> connectFuture = new CompletableFuture<>();
 


### PR DESCRIPTION
This replaces the existing `ImapClientFactory` constructors with a `TrustManagerFactory` field in the client configuration. If a `TrustManagerFactory` is specified we build an SSL context using that factory as opposed to the default `SSLContext`. This allows for a custom `TrustManagerFactory` per-session.

@cimmyv 