### PR TITLE
Add support for AUTHENTICATE PLAIN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ git:
   depth: 100
 
 sudo: false
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 
 before_install:
   - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip

--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -594,12 +594,15 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
   }
 
   private void trace(String prefix, ByteBuf in) {
-    int index = in.readerIndex();
-    skipControlCharacters(in);
-    String line = allBytesParser.parse(in);
-    logger.info("{}({}): {}", prefix, state().name(), line);
+    try {
+      int index = in.readerIndex();
+      String line = allBytesParser.parse(in);
+      logger.info("{}({}): {}", prefix, state().name(), line);
 
-    in.readerIndex(index);
+      in.readerIndex(index);
+    } catch (Exception e) {
+      logger.error("Caught exception while attempting to log tracing data!", e);
+    }
   }
 
   private static void skipControlCharacters(ByteBuf buffer) {

--- a/src/main/java/com/hubspot/imap/protocol/command/AppendCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/AppendCommand.java
@@ -23,7 +23,7 @@ import com.hubspot.imap.protocol.response.tagged.TaggedResponse;
 import com.hubspot.imap.utils.GmailUtils;
 import com.hubspot.imap.utils.ImapMessageWriterUtils;
 
-public class AppendCommand extends ContinuableCommand {
+public class AppendCommand extends ContinuableCommand<TaggedResponse> {
   private final String folderName;
   private final Set<MessageFlag> flags;
   private final Optional<ZonedDateTime> dateTime;

--- a/src/main/java/com/hubspot/imap/protocol/command/ContinuableCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/ContinuableCommand.java
@@ -6,11 +6,11 @@ import com.hubspot.imap.client.ImapClient;
 import com.hubspot.imap.protocol.response.ImapResponse;
 import com.hubspot.imap.protocol.response.tagged.TaggedResponse;
 
-public abstract class ContinuableCommand extends BaseImapCommand {
-  abstract CompletableFuture<TaggedResponse> continueAfterResponse(ImapResponse imapResponse, Throwable throwable);
-  ImapClient imapClient;
+public abstract class ContinuableCommand<T extends TaggedResponse> extends BaseImapCommand {
+  public abstract CompletableFuture<T> continueAfterResponse(ImapResponse imapResponse, Throwable throwable);
+  protected ImapClient imapClient;
 
-  ContinuableCommand(ImapClient imapClient, ImapCommandType type, String... args) {
+  protected ContinuableCommand(ImapClient imapClient, ImapCommandType type, String... args) {
     super(type, args);
     this.imapClient = imapClient;
   }

--- a/src/main/java/com/hubspot/imap/protocol/command/SimpleStringCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/SimpleStringCommand.java
@@ -1,0 +1,15 @@
+package com.hubspot.imap.protocol.command;
+
+public class SimpleStringCommand extends BaseImapCommand {
+  private final String string;
+
+  public SimpleStringCommand(String string) {
+    super(ImapCommandType.BLANK, false);
+    this.string = string;
+  }
+
+  @Override
+  public String commandString() {
+    return string;
+  }
+}

--- a/src/main/java/com/hubspot/imap/protocol/command/auth/AuthenticatePlainCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/auth/AuthenticatePlainCommand.java
@@ -1,5 +1,6 @@
 package com.hubspot.imap.protocol.command.auth;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.common.io.BaseEncoding;
@@ -32,7 +33,7 @@ public class AuthenticatePlainCommand extends ContinuableCommand<TaggedResponse>
     }
 
     String toEncode = NUL + user + NUL + password;
-    String base64EncodedAuthRequest = BaseEncoding.base64().encode(toEncode.getBytes());
+    String base64EncodedAuthRequest = BaseEncoding.base64().encode(toEncode.getBytes(StandardCharsets.UTF_8));
     return imapClient.send(new SimpleStringCommand(base64EncodedAuthRequest));
   }
 }

--- a/src/main/java/com/hubspot/imap/protocol/command/auth/AuthenticatePlainCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/auth/AuthenticatePlainCommand.java
@@ -1,0 +1,38 @@
+package com.hubspot.imap.protocol.command.auth;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.google.common.io.BaseEncoding;
+import com.hubspot.imap.client.ImapClient;
+import com.hubspot.imap.protocol.command.ContinuableCommand;
+import com.hubspot.imap.protocol.command.ImapCommandType;
+import com.hubspot.imap.protocol.command.SimpleStringCommand;
+import com.hubspot.imap.protocol.response.ImapResponse;
+import com.hubspot.imap.protocol.response.tagged.TaggedResponse;
+import com.spotify.futures.CompletableFutures;
+
+public class AuthenticatePlainCommand extends ContinuableCommand<TaggedResponse> {
+  private static final String PLAIN = "PLAIN";
+  private static final String NUL = "\0";
+
+  private final String user;
+  private final String password;
+
+  public AuthenticatePlainCommand(ImapClient imapClient,
+                                  String user,
+                                  String password, String... args) {
+    super(imapClient, ImapCommandType.AUTHENTICATE, PLAIN);
+    this.user = user;
+    this.password = password;
+  }
+
+  public CompletableFuture<TaggedResponse> continueAfterResponse(ImapResponse imapResponse, Throwable throwable) {
+    if (throwable != null) {
+      return CompletableFutures.exceptionallyCompletedFuture(throwable);
+    }
+
+    String toEncode = NUL + user + NUL + password;
+    String base64EncodedAuthRequest = BaseEncoding.base64().encode(toEncode.getBytes());
+    return imapClient.send(new SimpleStringCommand(base64EncodedAuthRequest));
+  }
+}

--- a/src/main/java/com/hubspot/imap/protocol/command/auth/XOAuth2Command.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/auth/XOAuth2Command.java
@@ -1,10 +1,12 @@
-package com.hubspot.imap.protocol.command;
-
-import com.google.common.collect.Lists;
-import com.google.common.io.BaseEncoding;
+package com.hubspot.imap.protocol.command.auth;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
+import com.hubspot.imap.protocol.command.BaseImapCommand;
+import com.hubspot.imap.protocol.command.ImapCommandType;
 
 public class XOAuth2Command extends BaseImapCommand {
   private static final BaseEncoding B64 = BaseEncoding.base64();

--- a/src/test/java/com/hubspot/imap/AuthenticationMechanismTest.java
+++ b/src/test/java/com/hubspot/imap/AuthenticationMechanismTest.java
@@ -1,0 +1,28 @@
+package com.hubspot.imap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import com.hubspot.imap.client.ImapClient;
+import com.hubspot.imap.protocol.command.ImapCommandType;
+import com.hubspot.imap.protocol.command.auth.AuthenticatePlainCommand;
+import com.hubspot.imap.protocol.response.tagged.TaggedResponse;
+
+
+@RunWith(Parameterized.class)
+public class AuthenticationMechanismTest extends ImapMultiServerTest {
+  @Parameter
+  public TestServerConfig testServerConfig;
+
+
+  @Test
+  public void itDoesSuccesfullyAuthenticatePlain() throws Exception {
+    try (ImapClient client = getClientForConfig(testServerConfig)) {
+      TaggedResponse capResponse = client.send(ImapCommandType.CAPABILITY).join();
+
+      client.send(new AuthenticatePlainCommand(client, testServerConfig.user(), testServerConfig.password())).join();
+    }
+  }
+}

--- a/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
+++ b/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
@@ -34,7 +34,7 @@ public class BaseGreenMailServerTest {
         .hostAndPort(HostAndPort.fromParts("localhost", greenMail.getImap().getPort()))
         .useSsl(false)
         .connectTimeoutMillis(1000)
-        .tracingEnabled(false)
+        .tracingEnabled(true)
         .build();
   }
 


### PR DESCRIPTION
As the title says this PR adds support for the `PLAIN` authentication mechanism.

I reworked a bit of the `ContinuableCommand` to make this easier to implement. Will need better `CAPABILITIES` support to make this really usable though.

@cimmyv @brian5021 