### PR TITLE
Choose preferred auth mechanism on login

### DIFF
--- a/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
+++ b/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.imap;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.net.ssl.TrustManagerFactory;
@@ -10,6 +11,7 @@ import org.immutables.value.Value.Style;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import com.hubspot.imap.protocol.capabilities.AuthMechanism;
 
@@ -21,6 +23,12 @@ import com.hubspot.imap.protocol.capabilities.AuthMechanism;
 @JsonDeserialize(as = ImapClientConfiguration.class)
 @JsonSerialize(as = ImapClientConfiguration.class)
 public interface ImapClientConfigurationIF {
+  List<AuthMechanism> DEFAULT_ALLOWED_AUTH_MECHANISMS = Lists.newArrayList(
+      AuthMechanism.XOAUTH2,
+      AuthMechanism.PLAIN,
+      AuthMechanism.LOGIN
+  );
+
   HostAndPort hostAndPort();
 
   AuthMechanism authType();
@@ -83,5 +91,10 @@ public interface ImapClientConfigurationIF {
   @Default
   default Optional<TrustManagerFactory> trustManagerFactory() {
     return Optional.empty();
+  }
+
+  @Default
+  default List<AuthMechanism> allowedAuthMechanisms() {
+    return DEFAULT_ALLOWED_AUTH_MECHANISMS;
   }
 }

--- a/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
+++ b/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
@@ -11,6 +11,7 @@ import org.immutables.value.Value.Style;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.net.HostAndPort;
+import com.hubspot.imap.protocol.capabilities.AuthMechanism;
 
 @Immutable
 @Style(
@@ -22,7 +23,7 @@ import com.google.common.net.HostAndPort;
 public interface ImapClientConfigurationIF {
   HostAndPort hostAndPort();
 
-  AuthType authType();
+  AuthMechanism authType();
 
   @Default
   default boolean useSsl() {
@@ -82,10 +83,5 @@ public interface ImapClientConfigurationIF {
   @Default
   default Optional<TrustManagerFactory> trustManagerFactory() {
     return Optional.empty();
-  }
-
-  enum AuthType {
-    PASSWORD,
-    XOAUTH2;
   }
 }

--- a/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
+++ b/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
@@ -11,9 +11,9 @@ import org.immutables.value.Value.Style;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import com.hubspot.imap.protocol.capabilities.AuthMechanism;
+import com.hubspot.imap.utils.ConfigDefaults;
 
 @Immutable
 @Style(
@@ -23,12 +23,6 @@ import com.hubspot.imap.protocol.capabilities.AuthMechanism;
 @JsonDeserialize(as = ImapClientConfiguration.class)
 @JsonSerialize(as = ImapClientConfiguration.class)
 public interface ImapClientConfigurationIF {
-  List<AuthMechanism> DEFAULT_ALLOWED_AUTH_MECHANISMS = Lists.newArrayList(
-      AuthMechanism.XOAUTH2,
-      AuthMechanism.PLAIN,
-      AuthMechanism.LOGIN
-  );
-
   HostAndPort hostAndPort();
 
   AuthMechanism authType();
@@ -95,6 +89,6 @@ public interface ImapClientConfigurationIF {
 
   @Default
   default List<AuthMechanism> allowedAuthMechanisms() {
-    return DEFAULT_ALLOWED_AUTH_MECHANISMS;
+    return ConfigDefaults.DEFAULT_ALLOWED_AUTH_MECHANISMS;
   }
 }

--- a/src/main/java/com/hubspot/imap/client/ImapClient.java
+++ b/src/main/java/com/hubspot/imap/client/ImapClient.java
@@ -83,7 +83,6 @@ import io.netty.util.concurrent.Promise;
 public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, Closeable {
 
   private static final String KEEP_ALIVE_HANDLER = "imap noop keep alive";
-  private static final List<AuthMechanism> SUPPORTED_AUTH_MECHANISMS = Lists.newArrayList(AuthMechanism.XOAUTH2, AuthMechanism.PLAIN, AuthMechanism.LOGIN);
 
   private final Logger logger;
   private final ImapClientConfiguration configuration;
@@ -148,7 +147,7 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
 
   public CompletableFuture<TaggedResponse> login(String userName, String authToken) {
     return capability().thenCompose(cpb -> {
-      Optional<AuthMechanism> firstSupportedMechanism = SUPPORTED_AUTH_MECHANISMS.stream()
+      Optional<AuthMechanism> firstSupportedMechanism = configuration.allowedAuthMechanisms().stream()
           .filter(authMechanism -> cpb.getAuthMechanisms().contains(authMechanism))
           .findFirst();
 

--- a/src/main/java/com/hubspot/imap/protocol/capabilities/AuthCapability.java
+++ b/src/main/java/com/hubspot/imap/protocol/capabilities/AuthCapability.java
@@ -1,6 +1,6 @@
 package com.hubspot.imap.protocol.capabilities;
 
-public class AuthCapability {
+public class AuthCapability implements Capability {
 
   private final AuthMechanism mechanism;
 
@@ -14,5 +14,10 @@ public class AuthCapability {
 
   public AuthMechanism getMechanism() {
     return mechanism;
+  }
+
+  @Override
+  public String getCapability() {
+    return StandardCapabilities.AUTH + "=" + getMechanism().name();
   }
 }

--- a/src/main/java/com/hubspot/imap/protocol/capabilities/AuthMechanism.java
+++ b/src/main/java/com/hubspot/imap/protocol/capabilities/AuthMechanism.java
@@ -17,6 +17,6 @@ public enum AuthMechanism {
   private static final Map<String, AuthMechanism> INDEX = Maps.uniqueIndex(Arrays.asList(AuthMechanism.values()), authMechanism -> authMechanism.name().toLowerCase());
 
   public static AuthMechanism fromString(String name) {
-    return INDEX.getOrDefault(name, AuthMechanism.UNKNOWN);
+    return INDEX.getOrDefault(name.toLowerCase(), AuthMechanism.UNKNOWN);
   }
 }

--- a/src/main/java/com/hubspot/imap/protocol/capabilities/Capabilities.java
+++ b/src/main/java/com/hubspot/imap/protocol/capabilities/Capabilities.java
@@ -48,6 +48,8 @@ public class Capabilities {
       if (parts.length < 2) {
         return StandardCapabilities.AUTH;
       }
+
+      return new AuthCapability(parts[1]);
     }
 
     return StandardCapabilities.fromString(capability).orElse(new UnknownCapability(capability));

--- a/src/main/java/com/hubspot/imap/utils/ConfigDefaults.java
+++ b/src/main/java/com/hubspot/imap/utils/ConfigDefaults.java
@@ -1,0 +1,17 @@
+package com.hubspot.imap.utils;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.hubspot.imap.protocol.capabilities.AuthMechanism;
+
+public class ConfigDefaults {
+  private ConfigDefaults() {
+  }
+
+  public static final List<AuthMechanism> DEFAULT_ALLOWED_AUTH_MECHANISMS = ImmutableList.of(
+      AuthMechanism.XOAUTH2,
+      AuthMechanism.PLAIN,
+      AuthMechanism.LOGIN
+  );
+}

--- a/src/test/java/com/hubspot/imap/AuthenticationMechanismTest.java
+++ b/src/test/java/com/hubspot/imap/AuthenticationMechanismTest.java
@@ -1,5 +1,7 @@
 package com.hubspot.imap;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -8,6 +10,7 @@ import org.junit.runners.Parameterized.Parameter;
 import com.hubspot.imap.client.ImapClient;
 import com.hubspot.imap.protocol.command.ImapCommandType;
 import com.hubspot.imap.protocol.command.auth.AuthenticatePlainCommand;
+import com.hubspot.imap.protocol.response.ResponseCode;
 import com.hubspot.imap.protocol.response.tagged.TaggedResponse;
 
 
@@ -16,13 +19,21 @@ public class AuthenticationMechanismTest extends ImapMultiServerTest {
   @Parameter
   public TestServerConfig testServerConfig;
 
-
   @Test
   public void itDoesSuccesfullyAuthenticatePlain() throws Exception {
     try (ImapClient client = getClientForConfig(testServerConfig)) {
       TaggedResponse capResponse = client.send(ImapCommandType.CAPABILITY).join();
 
       client.send(new AuthenticatePlainCommand(client, testServerConfig.user(), testServerConfig.password())).join();
+    }
+  }
+
+  @Test
+  public void itDoesSuccesfullyChooseSuccessfulAuthMechanismOnLogin() throws Exception {
+    try (ImapClient client = getClientForConfig(testServerConfig)) {
+      TaggedResponse response = client.login(testServerConfig.user(), testServerConfig.password()).join();
+
+      assertThat(response.getCode()).isEqualTo(ResponseCode.OK);
     }
   }
 }

--- a/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
+++ b/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
@@ -7,8 +7,8 @@ import org.junit.Before;
 import org.junit.Rule;
 
 import com.google.common.net.HostAndPort;
-import com.hubspot.imap.ImapClientConfigurationIF.AuthType;
 import com.hubspot.imap.client.ImapClient;
+import com.hubspot.imap.protocol.capabilities.AuthMechanism;
 import com.icegreen.greenmail.junit.GreenMailRule;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMailUtil;
@@ -30,7 +30,7 @@ public class BaseGreenMailServerTest {
 
   protected ImapClientConfiguration getImapConfig() {
     return ImapClientConfiguration.builder()
-        .authType(AuthType.PASSWORD)
+        .authType(AuthMechanism.LOGIN)
         .hostAndPort(HostAndPort.fromParts("localhost", greenMail.getImap().getPort()))
         .useSsl(false)
         .connectTimeoutMillis(1000)

--- a/src/test/java/com/hubspot/imap/ImapMultiServerTest.java
+++ b/src/test/java/com/hubspot/imap/ImapMultiServerTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +18,8 @@ import com.hubspot.imap.client.ImapClient;
 import com.hubspot.imap.protocol.exceptions.ConnectionClosedException;
 
 public abstract class ImapMultiServerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(ImapMultiServerTest.class);
+
   private static List<TestServerConfig> getTestConfigs() throws IOException {
     InputStream inputStream = Thread.currentThread().getContextClassLoader()
         .getResourceAsStream("profiles.yaml");
@@ -30,6 +34,7 @@ public abstract class ImapMultiServerTest {
     try {
       return getTestConfigs();
     } catch (Exception e) {
+      LOG.error("Failed to load test configs!", e);
       return Collections.emptyList();
     }
   }


### PR DESCRIPTION
This updates the login code to first send `CAPABILITY` and then choose an authentication mechanism to use based on the returned capabilities, unless a specific auth mechanism is specified.

currently only `XOAUTH2`, `PLAIN` and `LOGIN` are supported.

@cimmyv @brian5021 