### PR TITLE
Avoid Unnecessary Duplication

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -1,9 +1,7 @@
 package com.hubspot.imap.protocol;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -491,13 +489,13 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
 
   @Timed
   Optional<Message> parseBodyContent(ByteBuf in) throws ResponseParseException {
-    Optional<String> body = bufferedBodyParser.parse(in);
+    Optional<InputStream> body = bufferedBodyParser.parse(in);
     if (!body.isPresent()) {
       return Optional.empty();
     }
 
-    try (InputStream inputStream = new ByteArrayInputStream(body.get().getBytes(StandardCharsets.UTF_8))) {
-      return Optional.of(messageBuilder.parseMessage(inputStream));
+    try {
+      return Optional.of(messageBuilder.parseMessage(body.get()));
     } catch (IOException|NullPointerException e) {
       throw new ResponseParseException(e);
     }

--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -489,13 +489,13 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
 
   @Timed
   Optional<Message> parseBodyContent(ByteBuf in) throws ResponseParseException {
-    Optional<InputStream> body = bufferedBodyParser.parse(in);
-    if (!body.isPresent()) {
+    Optional<InputStream> bodyInputStream = bufferedBodyParser.parse(in);
+    if (!bodyInputStream.isPresent()) {
       return Optional.empty();
     }
 
     try {
-      return Optional.of(messageBuilder.parseMessage(body.get()));
+      return Optional.of(messageBuilder.parseMessage(bodyInputStream.get()));
     } catch (IOException|NullPointerException e) {
       throw new ResponseParseException(e);
     }


### PR DESCRIPTION
Instead of parsing the ByteBuffer into a String, then recopying that String back into bytes, and then wrapping it in an InputSteam, we can instead copy the ByteBuffer once, wrap it in an input stream and pass that along to the messageBuilder where it is needed

@zklapow 