### PR TITLE
Terminate message lines with CRLF

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/command/AppendCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/AppendCommand.java
@@ -34,7 +34,7 @@ public class AppendCommand extends ContinuableCommand<TaggedResponse> {
     this.folderName = folderName;
     this.flags = flags;
     this.dateTime = dateTime;
-    this.stringLiteralCommand = new StringLiteralCommand(ImapMessageWriterUtils.messageBodyToString(message), Charset.forName(message.getBody().getCharset()));
+    this.stringLiteralCommand = new StringLiteralCommand(ImapMessageWriterUtils.messageBodyToStringCRLF(message), Charset.forName(message.getBody().getCharset()));
   }
 
   public StringLiteralCommand getStringLiteralCommand() {

--- a/src/main/java/com/hubspot/imap/utils/ImapMessageWriterUtils.java
+++ b/src/main/java/com/hubspot/imap/utils/ImapMessageWriterUtils.java
@@ -18,4 +18,12 @@ public class ImapMessageWriterUtils {
     writer.writeMessage(imapMessage.getBody(), outputStream);
     return outputStream.toString(imapMessage.getBody().getCharset());
   }
+
+  public static String messageBodyToStringCRLF(ImapMessage imapMessage) throws UnfetchedFieldException, IOException {
+    return terminateLinesWithCRLF(messageBodyToString(imapMessage));
+  }
+
+  public static String terminateLinesWithCRLF(String messageString) {
+    return messageString.replaceAll("((?<!\\r)\\n|\\r(?!\\n))", "\r\n");
+  }
 }

--- a/src/test/java/com/hubspot/imap/ImapMessageWriterUtilsTest.java
+++ b/src/test/java/com/hubspot/imap/ImapMessageWriterUtilsTest.java
@@ -1,0 +1,40 @@
+package com.hubspot.imap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.hubspot.imap.utils.ImapMessageWriterUtils;
+
+public class ImapMessageWriterUtilsTest {
+
+  @Test
+  public void replacesLineWithCLRF() throws Exception {
+    String withN = "This is \n a test \n";
+    String withR = "This is \r a test \r";
+    String correct = "This is \r\n a test \r\n";
+    String incorrect = "This is a test";
+
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withN)).isEqualTo(correct);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withR)).isEqualTo(correct);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withN)).isNotEqualTo(withN);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withR)).isNotEqualTo(withR);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withN)).isNotEqualTo(incorrect);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withR)).isNotEqualTo(incorrect);
+  }
+
+  @Test
+  public void replacesLineWithCLRFComplex() throws Exception {
+    String withBoth = "Th\r\nis is \n\n a te\rst \n";
+    String withReverse = "Th\r\nis is \n\r a te\nst \r";
+    String correct = "Th\r\nis is \r\n\r\n a te\r\nst \r\n";
+    String incorrect = "This is a test";
+
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withBoth)).isEqualTo(correct);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withReverse)).isEqualTo(correct);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withBoth)).isNotEqualTo(withBoth);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withReverse)).isNotEqualTo(withReverse);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withBoth)).isNotEqualTo(incorrect);
+    assertThat(ImapMessageWriterUtils.terminateLinesWithCRLF(withReverse)).isNotEqualTo(incorrect);
+  }
+}


### PR DESCRIPTION
Appending messages that have isolated CR or LF is failing with servers who strictly follow `RFC 2821 - 2.3.7 Lines` which states:

> SMTP commands and, unless altered by a service extension, message
   data, are transmitted in "lines".  Lines consist of zero or more data
   characters terminated by the sequence ASCII character "CR" (hex value
   0D) followed immediately by ASCII character "LF" (hex value 0A).
   This termination sequence is denoted as <CRLF> in this document.
   Conforming implementations MUST NOT recognize or generate any other
   character or character sequence as a line terminator.  Limits MAY be
   imposed on line lengths by servers (see section 4.5.3).

> In addition, the appearance of "bare" "CR" or "LF" characters in text
   (i.e., either without the other) has a long history of causing
   problems in mail implementations and applications that use the mail
   system as a tool.  SMTP client implementations MUST NOT transmit
   these characters except when they are intended as line terminators
   and then MUST, as indicated above, transmit them only as a <CRLF>
   sequence.

This change finds these lone line terminals with the regex expression `((?<!\\r)\\n|\\r(?!\\n))` and replaces them with `\r\n` (CRLF). This should not be seen as a long term fix and eventually we should implement our own CRLFOutputStream (https://github.com/javaee/javamail/blob/master/demo/src/main/java/CRLFOutputStream.java) that accomplishes the same task in a far more efficient way

@zklapow @cimmyv 