### PR TITLE
Copy into byte[] instead of String

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -3,7 +3,6 @@ package com.hubspot.imap.protocol;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -491,12 +490,12 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
 
   @Timed
   Optional<Message> parseBodyContent(ByteBuf in) throws ResponseParseException {
-    Optional<String> body = bufferedBodyParser.parse(in);
+    Optional<byte[]> body = bufferedBodyParser.parse(in);
     if (!body.isPresent()) {
       return Optional.empty();
     }
 
-    try (InputStream inputStream = new ByteArrayInputStream(body.get().getBytes(StandardCharsets.UTF_8))) {
+    try (InputStream inputStream = new ByteArrayInputStream(body.get())) {
       return Optional.of(messageBuilder.parseMessage(inputStream));
     } catch (IOException|NullPointerException e) {
       throw new ResponseParseException(e);


### PR DESCRIPTION
This should achieve the goal that https://github.com/HubSpot/NioImapClient/pull/38 was trying to accomplish.

Instead of copying the buffer into a stream or another ByteBuffer, we will copy it into a byte[]. This saves us one step of copying like #38 had but shouldn't create a memory leak

@cimmyv @zklapow 
