### PR TITLE
Write Imap Messages to CRLF Outputstream

### DIFF
--- a/src/main/java/com/hubspot/imap/utils/CRLFOutputStream.java
+++ b/src/main/java/com/hubspot/imap/utils/CRLFOutputStream.java
@@ -1,0 +1,59 @@
+package com.hubspot.imap.utils;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class CRLFOutputStream extends FilterOutputStream {
+
+  private static final int CR = '\r';
+  private static final int LF = '\n';
+
+  private int previous = 0;
+
+  public CRLFOutputStream(OutputStream out) {
+    super(out);
+  }
+
+  public void write(int b) throws IOException {
+    if (b == CR) {
+      writeCRLF();
+    } else if (b == LF && previous != CR) {
+      writeCRLF();
+    } else {
+      out.write(b);
+    }
+
+    previous = b;
+  }
+
+  public void write(byte b[], int off, int len) throws IOException {
+    int begin = off;
+    int adjustedLen = len + off;
+
+    for (int i = off; i < adjustedLen; i++) {
+      int current = b[i];
+      if (current == CR) {
+        out.write(b, begin, i - begin);
+        writeCRLF();
+        begin = i + 1;
+      } else if (current == LF) {
+        if (previous != CR) {
+          out.write(b, begin, i - begin);
+          writeCRLF();
+        }
+        begin = i + 1;
+      }
+
+      previous = current;
+    }
+    if (adjustedLen > begin) {
+      out.write(b, begin, adjustedLen - begin);
+    }
+  }
+
+  private void writeCRLF() throws IOException {
+    out.write(CR);
+    out.write(LF);
+  }
+}

--- a/src/main/java/com/hubspot/imap/utils/ImapMessageWriterUtils.java
+++ b/src/main/java/com/hubspot/imap/utils/ImapMessageWriterUtils.java
@@ -14,8 +14,9 @@ public class ImapMessageWriterUtils {
   public static String messageBodyToString(ImapMessage imapMessage) throws UnfetchedFieldException, IOException {
     MessageWriter writer = new DefaultMessageWriter();
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    CRLFOutputStream crlfOutputStream = new CRLFOutputStream(outputStream);
 
-    writer.writeMessage(imapMessage.getBody(), outputStream);
+    writer.writeMessage(imapMessage.getBody(), crlfOutputStream);
     return outputStream.toString(imapMessage.getBody().getCharset());
   }
 }

--- a/src/test/java/com/hubspot/imap/client/ImapClientTest.java
+++ b/src/test/java/com/hubspot/imap/client/ImapClientTest.java
@@ -419,7 +419,7 @@ public class ImapClientTest extends BaseGreenMailServerTest {
     header.addField(DefaultFieldParser.parse("Date: 10-MAY-1994 00:00:00 -0000 (UTC)"));
     header.addField(DefaultFieldParser.parse("Message-ID: 12345"));
 
-    Envelope envelope = new Envelope.Builder().setDate(ZonedDateTime.of(1994, 5, 10, 0,0,0,0, ZoneId.of("UTC")));
+    Envelope envelope = new Envelope.Builder().setDate(ZonedDateTime.of(1994, 5, 10, 0, 0, 0, 0, ZoneId.of("UTC")));
 
     Body body = BasicBodyFactory.INSTANCE.textBody("This is a test");
 


### PR DESCRIPTION
Appending messages that have isolated CR or LF is failing with servers who strictly follow RFC 2821 - 2.3.7 Lines which states:

SMTP commands and, unless altered by a service extension, message
data, are transmitted in "lines". Lines consist of zero or more data
characters terminated by the sequence ASCII character "CR" (hex value
0D) followed immediately by ASCII character "LF" (hex value 0A).
This termination sequence is denoted as in this document.
Conforming implementations MUST NOT recognize or generate any other
character or character sequence as a line terminator. Limits MAY be
imposed on line lengths by servers (see section 4.5.3).

In addition, the appearance of "bare" "CR" or "LF" characters in text
(i.e., either without the other) has a long history of causing
problems in mail implementations and applications that use the mail
system as a tool. SMTP client implementations MUST NOT transmit
these characters except when they are intended as line terminators
and then MUST, as indicated above, transmit them only as a 
sequence.

This checks as we are writing to the output stream whether or not we have one of these isolated CR or LF and replaces it with CRLF.

@cimmyv 