### PR TITLE
If Envelope is missing but we have headers, parse them

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -13,8 +13,10 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.dom.Body;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.dom.MessageServiceFactory;
+import org.apache.james.mime4j.message.AbstractEntity;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
 import org.apache.james.mime4j.stream.MimeConfig;
 import org.slf4j.Logger;
@@ -39,6 +41,7 @@ import com.hubspot.imap.protocol.folder.FolderFlags;
 import com.hubspot.imap.protocol.folder.FolderMetadata;
 import com.hubspot.imap.protocol.message.Envelope;
 import com.hubspot.imap.protocol.message.ImapMessage;
+import com.hubspot.imap.protocol.message.UnfetchedFieldException;
 import com.hubspot.imap.protocol.response.ContinuationResponse;
 import com.hubspot.imap.protocol.response.ResponseCode;
 import com.hubspot.imap.protocol.response.events.ByeEvent;
@@ -334,6 +337,7 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
   }
 
   private void messageComplete() {
+    setEnvelopeIfAbsent();
     ImapMessage message = currentMessage.build();
     currentMessage = null;
 
@@ -353,6 +357,22 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
     }
 
     checkpoint(State.RESET);
+  }
+
+  private void setEnvelopeIfAbsent() {
+    try {
+      currentMessage.getEnvelope();
+    } catch (UnfetchedFieldException e) {
+      try {
+        Body body = currentMessage.getBody();
+        if (body instanceof AbstractEntity) {
+          AbstractEntity message = (AbstractEntity) body;
+          currentMessage.setEnvelope(EnvelopeParser.fromHeader(message.getHeader()));
+        }
+      } catch (UnfetchedFieldException e1) {
+        // ignored
+      }
+    }
   }
 
   private void handleTagged(ByteBuf in, List<Object> out) {

--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -367,10 +367,10 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
         Body body = currentMessage.getBody();
         if (body instanceof AbstractEntity) {
           AbstractEntity message = (AbstractEntity) body;
-          currentMessage.setEnvelope(EnvelopeParser.fromHeader(message.getHeader()));
+          currentMessage.setEnvelope(EnvelopeParser.parseHeader(message.getHeader()));
         }
       } catch (UnfetchedFieldException e1) {
-        // ignored
+        // ignored - no body, nothing to build envelope from
       }
     }
   }

--- a/src/main/java/com/hubspot/imap/utils/enums/EnvelopeField.java
+++ b/src/main/java/com/hubspot/imap/utils/enums/EnvelopeField.java
@@ -1,0 +1,30 @@
+package com.hubspot.imap.utils.enums;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum EnvelopeField {
+  DATE("date"),
+  SUBJECT("subject"),
+  FROM("from"),
+  SENDER("sender"),
+  REPLY_TO("replyto"),
+  TO("to"),
+  CC("cc"),
+  BCC("bcc"),
+  IN_REPLY_TO("inreplyto"),
+  MESSAGE_ID("message-id");
+
+  private final String fieldName;
+  public static final Map<String, EnvelopeField> NAME_INDEX = Arrays.stream(EnvelopeField.values()).collect(Collectors.toMap(EnvelopeField::getFieldName, Function.identity()));
+
+  EnvelopeField(String fieldName) {
+    this.fieldName = fieldName;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+}

--- a/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
@@ -1,14 +1,5 @@
 package com.hubspot.imap.utils.parsers.fetch;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
-import com.hubspot.imap.protocol.message.Envelope;
-import com.hubspot.imap.protocol.message.ImapAddress;
-import com.hubspot.imap.protocol.message.ImapAddress.Builder;
-import com.hubspot.imap.utils.NilMarker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -17,13 +8,55 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.james.mime4j.dom.Header;
+import org.apache.james.mime4j.stream.Field;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.hubspot.imap.protocol.message.Envelope;
+import com.hubspot.imap.protocol.message.ImapAddress;
+import com.hubspot.imap.protocol.message.ImapAddress.Builder;
+import com.hubspot.imap.utils.NilMarker;
+
 public class EnvelopeParser {
+
+  enum EnvelopeField {
+    DATE("date"),
+    SUBJECT("subject"),
+    FROM("from"),
+    SENDER("sender"),
+    REPLY_TO("replyto"),
+    TO("to"),
+    CC("cc"),
+    BCC("bcc"),
+    IN_REPLY_TO("inreplyto"),
+    MESSAGE_ID("message-id");
+
+    private final String fieldName;
+    static final Map<String, EnvelopeField> NAME_INDEX = Arrays.stream(EnvelopeField.values()).collect(Collectors.toMap(EnvelopeField::getFieldName, Function.identity()));
+
+    EnvelopeField(String fieldName) {
+      this.fieldName = fieldName;
+    }
+
+    String getFieldName() {
+      return fieldName;
+    }
+  }
+
   private static final Logger LOGGER = LoggerFactory.getLogger(EnvelopeParser.class);
+  private static final Splitter COMMA_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
 
   static final DateTimeFormatter RFC2822_FORMATTER = DateTimeFormatter.ofPattern("[EEE, ]d MMM yyyy H:m:s[ zzz][ Z][ (z)]").withLocale(Locale.US);
 
@@ -40,7 +73,7 @@ public class EnvelopeParser {
    * @param in ByteBuf containing the full envelope response.
    * @return Parsed Envelope object.
    */
-  public Envelope parse(List<Object> in) {
+  public static Envelope parse(List<Object> in) {
     LOGGER.debug("Parsing envelope response: {}", in);
 
     String dateString = castToString(in.get(0));
@@ -79,8 +112,49 @@ public class EnvelopeParser {
     return envelope.build();
   }
 
+  public static Envelope fromHeader(Header header) {
+    Map<String, String> envelopeFields = header.getFields().stream()
+        .filter(f -> EnvelopeField.NAME_INDEX.containsKey(f.getName().toLowerCase()))
+        .collect(Collectors.toMap(f -> f.getName().toLowerCase(), Field::getBody));
+    Envelope.Builder envelope = new Envelope.Builder();
+
+    String dateString = envelopeFields.get(EnvelopeField.DATE.getFieldName());
+    List<ImapAddress> fromAddress = emailAddressesFromStringList(envelopeFields.get(EnvelopeField.FROM.getFieldName()));
+    envelope.setDateString(dateString)
+        .setSubject(envelopeFields.get(EnvelopeField.SUBJECT.getFieldName()))
+        .setFrom(fromAddress)
+        .setSender(emailAddressesFromStringList(envelopeFields.get(EnvelopeField.SENDER.getFieldName()), fromAddress))
+        .setReplyTo(emailAddressesFromStringList(envelopeFields.get(EnvelopeField.REPLY_TO.getFieldName()), fromAddress))
+        .setTo(emailAddressesFromStringList(envelopeFields.get(EnvelopeField.TO.getFieldName())))
+        .setCc(emailAddressesFromStringList(envelopeFields.get(EnvelopeField.CC.getFieldName())))
+        .setBcc(emailAddressesFromStringList(envelopeFields.get(EnvelopeField.BCC.getFieldName())))
+        .setInReplyTo(envelopeFields.get(EnvelopeField.IN_REPLY_TO.getFieldName()))
+        .setMessageId(envelopeFields.get(EnvelopeField.MESSAGE_ID.getFieldName()));
+
+    try {
+      if (!Strings.isNullOrEmpty(dateString)) {
+        envelope.setDate(parseDate(dateString));
+      }
+    } catch (DateTimeParseException e) {
+      LOGGER.debug("Failed to parse date {}", header.getField("date").getBody(), e);
+    }
+    return envelope.build();
+  }
+
+  private static List<ImapAddress> emailAddressesFromStringList(String addresses) {
+    return Strings.isNullOrEmpty(addresses) ?
+        Collections.EMPTY_LIST :
+        COMMA_SPLITTER.splitToList(addresses).stream().map(address -> new Builder().setAddress(address)).collect(Collectors.toList());
+  }
+
+  private static List<ImapAddress> emailAddressesFromStringList(String addresses, List<ImapAddress> defaults) {
+    return Strings.isNullOrEmpty(addresses) ?
+        defaults :
+        COMMA_SPLITTER.splitToList(addresses).stream().map(address -> new Builder().setAddress(address)).collect(Collectors.toList());
+  }
+
   @SuppressWarnings("unchecked")
-  private List<Object> castToList(Object object) {
+  private static List<Object> castToList(Object object) {
     if (object instanceof String) {
       String string = ((String) object);
       if (string.startsWith("NIL")) {
@@ -97,7 +171,7 @@ public class EnvelopeParser {
   }
 
   @SuppressWarnings("unchecked")
-  private String castToString(Object object) {
+  private static String castToString(Object object) {
     if (object instanceof String) {
       return ((String) object);
     } else if (object instanceof NilMarker) {
@@ -108,7 +182,7 @@ public class EnvelopeParser {
   }
 
   @SuppressWarnings("unchecked")
-  private List<ImapAddress> emailAddressesFromNestedList(List<Object> in) {
+  private static List<ImapAddress> emailAddressesFromNestedList(List<Object> in) {
     if (in.size() == 0) {
       return new ArrayList<>();
     }

--- a/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParseTest.java
+++ b/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParseTest.java
@@ -4,7 +4,13 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
+import org.apache.james.mime4j.dom.Header;
+import org.apache.james.mime4j.dom.address.Mailbox;
+import org.apache.james.mime4j.field.Fields;
+import org.apache.james.mime4j.message.HeaderImpl;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.hubspot.imap.protocol.message.Envelope;
@@ -19,14 +25,29 @@ public class EnvelopeParseTest {
   private static final byte[] TEST_ENVELOPE = "(\"Tue, 28 Jul 2015 14:03:15 +0000\" \"Declined: weekly tennis @ Tue Jul 28, 2015 7pm - 9pm (jhuang@hubspot.com)\" ((\"Peter Casinelli\" NIL \"pcasinelli\" \"hubspot.com\")) ((\"Calendar <calendar-notification@google.com>\" NIL \"Google\" NIL)) ((\"Peter Casinelli\" NIL \"pcasinelli\" \"hubspot.com\")) ((NIL NIL \"jhuang\" \"hubspot.com\")) NIL NIL NIL \"<001a1135b6f27860f9051befeeb2@google.com>\"))\n".getBytes(StandardCharsets.UTF_8);
   private static final byte[] TEST_ENVELOPE_EMPTY_SUBJECT = "(\"Fri, 23 Jun 2017 17:55:45 +0200\" \"\" ((\"Test Name\" NIL \"testing0478\" \"gmail.com\")) ((\"Test Again\" NIL \"test12345\" \"gmail.com\")) ((\"Test Other\" NIL \"test456\" \"gmail.com\")) ((NIL NIL \"info\" \"test.com\")) NIL NIL NIL \"<testmessageid@mail.gmail.com>\")".getBytes(StandardCharsets.UTF_8);
 
+  private static final Mailbox ADDRESS1 = new Mailbox("bcox5021", "gmail.com");
+  private static final Mailbox ADDRESS2 = new Mailbox("bcox", "hubspot.com");
+  private static final Mailbox ADDRESS3 = new Mailbox("brian", "itscharlieb.com");
   private static final NestedArrayParser.Recycler<String> ARRAY_PARSER_RECYCLER = new Recycler<>(new LiteralStringParser(new SoftReferencedAppendableCharSequence(1000), 100000));
+
+  private Header header;
+
+  @Before
+  public void setup() {
+    header = new HeaderImpl();
+    header.addField(Fields.bcc());
+    header.addField(Fields.cc(ADDRESS2));
+    header.addField(Fields.to(ADDRESS3));
+    header.addField(Fields.date(Date.from(EnvelopeParser.parseDate("Mon, 29 Jan 2018 19:23:47 -0500").toInstant())));
+    header.addField(Fields.from(ADDRESS1));
+    header.addField(Fields.messageId("<CAKSL6jJTr_uwGqRDh4juaLLWdkmw0NyGcyiCYMFD15xm_A0=+w@mail.gmail.com>"));
+    header.addField(Fields.subject("Multiple two field"));
+  }
 
   @Test
   public void testCanParseEnvelope() throws Exception {
-    EnvelopeParser envelopeParser = new EnvelopeParser();
-
     NestedArrayParser<String> nestedArrayParser = ARRAY_PARSER_RECYCLER.get();
-    Envelope envelope = envelopeParser.parse(nestedArrayParser.parse(wrappedBuffer(TEST_ENVELOPE)));
+    Envelope envelope = EnvelopeParser.parse(nestedArrayParser.parse(wrappedBuffer(TEST_ENVELOPE)));
     nestedArrayParser.recycle();
 
     assertThat(envelope.getSubject()).isNotEmpty();
@@ -34,13 +55,18 @@ public class EnvelopeParseTest {
 
   @Test
   public void testCanParseEnvelope2() throws Exception {
-    EnvelopeParser envelopeParser = new EnvelopeParser();
-
     NestedArrayParser<String> nestedArrayParser = ARRAY_PARSER_RECYCLER.get();
-    Envelope envelope = envelopeParser.parse(nestedArrayParser.parse(wrappedBuffer(TEST_ENVELOPE_EMPTY_SUBJECT)));
+    Envelope envelope = EnvelopeParser.parse(nestedArrayParser.parse(wrappedBuffer(TEST_ENVELOPE_EMPTY_SUBJECT)));
     nestedArrayParser.recycle();
 
     assertThat(envelope.getSubject()).isEmpty();
     assertThat(envelope.getDateString()).isNotEmpty();
+  }
+
+  @Test
+  public void testCanParseHeader() throws Exception {
+    Envelope envelope = EnvelopeParser.parseHeader(header);
+    assertThat(envelope.getInReplyTo()).isNullOrEmpty();
+    assertThat(envelope.getMessageId()).isNotEmpty();
   }
 }


### PR DESCRIPTION
In cases where we can only fetch the body and not the envelope, manually parse the headers and build the envelope.