### PR TITLE
Fix parsing header addresses in EnvelopeParser

### DIFF
--- a/src/main/java/com/hubspot/imap/utils/enums/EnvelopeField.java
+++ b/src/main/java/com/hubspot/imap/utils/enums/EnvelopeField.java
@@ -10,11 +10,11 @@ public enum EnvelopeField {
   SUBJECT("subject"),
   FROM("from"),
   SENDER("sender"),
-  REPLY_TO("replyto"),
+  REPLY_TO("reply-to"),
   TO("to"),
   CC("cc"),
   BCC("bcc"),
-  IN_REPLY_TO("inreplyto"),
+  IN_REPLY_TO("in-reply-to"),
   MESSAGE_ID("message-id");
 
   private final String fieldName;


### PR DESCRIPTION
There is a personal component and an email component to the email address header. This change will split the string up accordingly and set the ImapAddress correctly

@cimmyv 