### PR TITLE
Handle when header has duplicate fields

### DIFF
--- a/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
@@ -91,7 +91,9 @@ public class EnvelopeParser {
   public static Envelope parseHeader(Header header) {
     Map<String, String> envelopeFields = header.getFields().stream()
         .filter(f -> EnvelopeField.NAME_INDEX.containsKey(f.getName().toLowerCase()))
-        .collect(Collectors.toMap(f -> f.getName().toLowerCase(), Field::getBody));
+        .collect(Collectors.groupingBy(field -> field.getName().toLowerCase(),
+            Collectors.mapping(Field::getBody, Collectors.joining(","))));
+
     Envelope.Builder envelope = new Envelope.Builder();
 
     String dateString = envelopeFields.get(EnvelopeField.DATE.getFieldName());


### PR DESCRIPTION
We were seeing cases where a header had multiple "TO" fields instead of listing them together in the field body. This joins them together to be handled like well formed headers