### PR TITLE
Parse internal dates with zones

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/message/ImapMessage.java
+++ b/src/main/java/com/hubspot/imap/protocol/message/ImapMessage.java
@@ -1,9 +1,6 @@
 package com.hubspot.imap.protocol.message;
 
-import static com.hubspot.imap.utils.formats.ImapDateFormat.INTERNALDATE_FORMATTERS;
-
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -14,6 +11,7 @@ import org.apache.james.mime4j.dom.Message;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.hubspot.imap.protocol.extension.gmail.GMailLabel;
+import com.hubspot.imap.utils.formats.ImapDateFormat;
 
 public interface ImapMessage {
 
@@ -86,14 +84,7 @@ public interface ImapMessage {
     }
 
     public Builder setInternalDate(String internalDate) {
-      for (DateTimeFormatter formatter : INTERNALDATE_FORMATTERS) {
-        try {
-          this.internalDate = Optional.of(ZonedDateTime.parse(internalDate.trim(), formatter));
-          return this;
-        } catch (Exception e) {
-          // swallow
-        }
-      }
+      this.internalDate = Optional.of(ImapDateFormat.fromStringToZonedDateTime(internalDate));
       return this;
     }
 

--- a/src/main/java/com/hubspot/imap/protocol/message/ImapMessage.java
+++ b/src/main/java/com/hubspot/imap/protocol/message/ImapMessage.java
@@ -1,8 +1,9 @@
 package com.hubspot.imap.protocol.message;
 
-import static com.hubspot.imap.utils.formats.ImapDateFormat.INTERNALDATE_FORMATTER;
+import static com.hubspot.imap.utils.formats.ImapDateFormat.INTERNALDATE_FORMATTERS;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -85,7 +86,14 @@ public interface ImapMessage {
     }
 
     public Builder setInternalDate(String internalDate) {
-      this.internalDate = Optional.of(ZonedDateTime.parse(internalDate.trim(), INTERNALDATE_FORMATTER));
+      for (DateTimeFormatter formatter : INTERNALDATE_FORMATTERS) {
+        try {
+          this.internalDate = Optional.of(ZonedDateTime.parse(internalDate.trim(), formatter));
+          return this;
+        } catch (Exception e) {
+          // swallow
+        }
+      }
       return this;
     }
 

--- a/src/main/java/com/hubspot/imap/utils/formats/ImapDateFormat.java
+++ b/src/main/java/com/hubspot/imap/utils/formats/ImapDateFormat.java
@@ -1,5 +1,6 @@
 package com.hubspot.imap.utils.formats;
 
+import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -24,7 +25,7 @@ public class ImapDateFormat {
 
   public static final DateTimeFormatter INTERNALDATE_FORMATTER = DateTimeFormatter.ofPattern("d-MMM-yyyy HH:mm:ss Z");
   private static final DateTimeFormatter INTERNALDATE_FORMATTER_WITH_ZONE = DateTimeFormatter.ofPattern("d-MMM-yyyy HH:mm:ss Z z");
-  public static final Set<DateTimeFormatter> INTERNALDATE_FORMATTERS = ImmutableSet.of(INTERNALDATE_FORMATTER, INTERNALDATE_FORMATTER_WITH_ZONE);
+  private static final Set<DateTimeFormatter> INTERNALDATE_FORMATTERS = ImmutableSet.of(INTERNALDATE_FORMATTER, INTERNALDATE_FORMATTER_WITH_ZONE);
 
   public static String toImapDateWithTimeString(ZonedDateTime d) {
     return IMAP_FULL_DATE_FORMAT.format(d);
@@ -32,5 +33,17 @@ public class ImapDateFormat {
 
   public static String toImapDateOnlyString(ZonedDateTime d) {
     return IMAP_SHORT_DATE_FORMAT.format(d);
+  }
+
+  public static ZonedDateTime fromStringToZonedDateTime(String dateString) {
+    for (DateTimeFormatter formatter : INTERNALDATE_FORMATTERS) {
+      try {
+        return ZonedDateTime.parse(dateString.trim(), formatter);
+      } catch (Exception e) {
+        // swallow
+      }
+    }
+
+    throw new DateTimeException(String.format("Failed to parse date string: '%s'", dateString));
   }
 }

--- a/src/main/java/com/hubspot/imap/utils/formats/ImapDateFormat.java
+++ b/src/main/java/com/hubspot/imap/utils/formats/ImapDateFormat.java
@@ -4,6 +4,9 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 
 public class ImapDateFormat {
   private static final DateTimeFormatter IMAP_FULL_DATE_FORMAT =
@@ -20,6 +23,8 @@ public class ImapDateFormat {
       .toFormatter(Locale.US);
 
   public static final DateTimeFormatter INTERNALDATE_FORMATTER = DateTimeFormatter.ofPattern("d-MMM-yyyy HH:mm:ss Z");
+  private static final DateTimeFormatter INTERNALDATE_FORMATTER_WITH_ZONE = DateTimeFormatter.ofPattern("d-MMM-yyyy HH:mm:ss Z z");
+  public static final Set<DateTimeFormatter> INTERNALDATE_FORMATTERS = ImmutableSet.of(INTERNALDATE_FORMATTER, INTERNALDATE_FORMATTER_WITH_ZONE);
 
   public static String toImapDateWithTimeString(ZonedDateTime d) {
     return IMAP_FULL_DATE_FORMAT.format(d);


### PR DESCRIPTION
This PR handles when the timezone is included in the internal date string i.e `12-Feb-2018 19:50:00 +0300 MSK` instead of `12-Feb-2018 19:50:00 +0300`. This causes our parsing to fail when using the traditional format `d-MMM-yyyy HH:mm:ss Z`.
Now we will try both formats, swallowing the exception if failure and breaking out of the loop if successful 