### PR TITLE
String Literal Support

### DIFF
--- a/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
@@ -84,20 +84,17 @@ public class AtomOrStringParser implements ByteBufParser<String> {
    * begins after any CLRF characters following the '}' character.
    */
   private String parseLiteral(ByteBuf buffer, AppendableCharSequence seq) {
-    int length = 0, digit = 0;
+    int length = 0;
 
     char c = (char) buffer.readUnsignedByte();
     while (c != '}') {
       if (Character.isDigit(c)) {
-        digit = Character.digit(c, 10);
+        int digit = Character.digit(c, 10);
         length = (length * 10) + digit;
         c = (char) buffer.readUnsignedByte();
       } else {
         throw new DecoderException(
-            String.format(
-                "Found non-digit character %c where a digit was expected",
-                c
-            )
+            String.format("Found non-digit character %c where a digit was expected", c)
         );
       }
     }

--- a/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
@@ -122,7 +122,6 @@ public class AtomOrStringParser implements ByteBufParser<String> {
     return c == '\n' || c == '\r';
   }
 
-
   private void append(AppendableCharSequence seq, char c) {
     if (size >= maxStringLength) {
       throw new TooLongFrameException("String is larger than " + maxStringLength + " bytes.");

--- a/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
@@ -93,14 +93,13 @@ public class AtomOrStringParser implements ByteBufParser<String> {
    * begins after any CLRF characters following the '}' character.
    */
   private String parseLiteral(ByteBuf buffer, AppendableCharSequence seq) {
-    StringBuilder digitBuilder = new StringBuilder();
+    int length = 0;
 
-    char c = ((char) buffer.readUnsignedByte());
+    char c = (char) buffer.readUnsignedByte();
     while (c != '}') {
-      digitBuilder.append(c);
-      c = ((char) buffer.readUnsignedByte());
+      length = (length * 10) + Character.getNumericValue(c);
+      c = (char) buffer.readUnsignedByte();
     }
-    int length = Integer.parseInt(digitBuilder.toString());
 
     if (length > 0) {
       c = (char) buffer.readUnsignedByte();

--- a/src/test/java/com/hubspot/imap/utils/parsers/AtomOrStringParserTest.java
+++ b/src/test/java/com/hubspot/imap/utils/parsers/AtomOrStringParserTest.java
@@ -12,8 +12,6 @@ import org.junit.Test;
 import com.hubspot.imap.utils.SoftReferencedAppendableCharSequence;
 import com.hubspot.imap.utils.parsers.string.AtomOrStringParser;
 
-import io.netty.handler.codec.DecoderException;
-
 public class AtomOrStringParserTest {
   private static final SoftReferencedAppendableCharSequence SEQUENCE_REF = new SoftReferencedAppendableCharSequence(1000);
   private static final AtomOrStringParser PARSER = new AtomOrStringParser(SEQUENCE_REF, 1000);
@@ -25,7 +23,6 @@ public class AtomOrStringParserTest {
   private static final byte[] ESCAPED_QUOTES_RESULT = Arrays.copyOfRange(ESCAPED_QUOTES, 1, ESCAPED_QUOTES.length - 1);
   private static final byte[] LITERAL = "{10}\nabcdefghij".getBytes(StandardCharsets.UTF_8);
   private static final byte[] LITERAL_RESULT = "abcdefghij".getBytes(StandardCharsets.UTF_8);
-  private static final byte[] LITERAL_MISMATCHING_LENGTH = "{10}\nabcdefghijk".getBytes(StandardCharsets.UTF_8);
 
   @Test
   public void testGivenUnquotedString_doesReturnWholeString() throws Exception {
@@ -49,10 +46,5 @@ public class AtomOrStringParserTest {
   public void testGivenStringWithLiteral_doesReturnLiteralWithCorrectLength() throws Exception {
     String result = PARSER.parse(wrappedBuffer(LITERAL));
     assertThat(result.getBytes(StandardCharsets.UTF_8)).isEqualTo(LITERAL_RESULT);
-  }
-
-  @Test(expected = DecoderException.class)
-  public void testGivenStringWithLiteralOfWrongLength_doesThrowDecoderException() {
-    PARSER.parse(wrappedBuffer(LITERAL_MISMATCHING_LENGTH));
   }
 }


### PR DESCRIPTION
This PR adds support for imap string literal resopnses as defined in [section 4.3 of RFC 3501](https://tools.ietf.org/html/rfc3501.html#section-4.3). The section allows responses of the following format

```
* LIST (\HasNoChildren) "/" {34}
A long string literal of length 34
```

Where the `{34}` defines the length of the ensuing string literal. This allows for more arbitrary special character support.

I added two unit tests to verify that
* Properly formatted string literals are parsed properly.
* ~String literals with invalid lengths throw decoder exceptions.~

