### PR TITLE
Correct Envelope Parsing From Headers

### DIFF
--- a/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
@@ -127,23 +127,23 @@ public class EnvelopeParser {
 
   @VisibleForTesting
   public static List<ImapAddress> emailAddressesFromStringList(String addresses, List<ImapAddress> defaults) {
-    return Strings.isNullOrEmpty(addresses)
-        ? defaults
-        : getSplitter(addresses)
-        .splitToList(addresses).stream()
-          .map(ADDRESS_SPLITTER::splitToList)
-          .map(EnvelopeParser::imapAddressFromParts)
-          .filter(Optional::isPresent)
-          .map(Optional::get)
-          .collect(Collectors.toList());
+    if (Strings.isNullOrEmpty(addresses)) {
+      return defaults;
+    }
+
+    return getSplitter(addresses).splitToList(addresses).stream()
+        .map(ADDRESS_SPLITTER::splitToList)
+        .map(EnvelopeParser::imapAddressFromParts)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
   }
 
   private static Splitter getSplitter(String addresses) {
     if (addresses.contains(">")) {
       return PARAMETER_COMMA_SPLITTER;
-    } else {
-      return COMMA_SPLITTER;
     }
+    return COMMA_SPLITTER;
   }
 
   private static Optional<ImapAddress> imapAddressFromParts(List<String> addressParts) {

--- a/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
@@ -151,7 +151,6 @@ public class EnvelopeParser {
       return Optional.empty();
     }
 
-
     Optional<String> emailAddressMaybe = addressParts.stream().filter(part -> part.contains("@")).findFirst();
 
     if (!emailAddressMaybe.isPresent()) {
@@ -159,7 +158,6 @@ public class EnvelopeParser {
     }
 
     String emailAddress = emailAddressMaybe.get();
-
     ImapAddress.Builder addressBuilder = new ImapAddress.Builder();
     addressBuilder.setAddress(emailAddress);
     int emailIndex = addressParts.indexOf(emailAddress);

--- a/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
@@ -1,7 +1,5 @@
 package com.hubspot.imap.utils.parsers.string;
 
-import java.nio.charset.StandardCharsets;
-
 import com.hubspot.imap.utils.SoftReferencedAppendableCharSequence;
 import com.hubspot.imap.utils.parsers.ByteBufParser;
 
@@ -25,8 +23,6 @@ public class AtomOrStringParser implements ByteBufParser<String> {
 
   public String parse(ByteBuf buffer) {
     AppendableCharSequence seq = sequenceRef.get();
-
-    seq.append(buffer.readCharSequence(length, StandardCharsets.UTF_8);
 
     seq.reset();
     size = 0;

--- a/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
@@ -1,5 +1,7 @@
 package com.hubspot.imap.utils.parsers.string;
 
+import java.nio.charset.StandardCharsets;
+
 import com.hubspot.imap.utils.SoftReferencedAppendableCharSequence;
 import com.hubspot.imap.utils.parsers.ByteBufParser;
 
@@ -23,6 +25,8 @@ public class AtomOrStringParser implements ByteBufParser<String> {
 
   public String parse(ByteBuf buffer) {
     AppendableCharSequence seq = sequenceRef.get();
+
+    seq.append(buffer.readCharSequence(length, StandardCharsets.UTF_8);
 
     seq.reset();
     size = 0;

--- a/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParseTest.java
+++ b/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParseTest.java
@@ -100,7 +100,6 @@ public class EnvelopeParseTest {
     String addresses1 = "brian@test.com, bill@test.com, bob@test.com";
     String addresses2 = "<brian@test.com>, <bill@test.com>, <bob@test.com>";
 
-
     List<ImapAddress> result = EnvelopeParser.emailAddressesFromStringList(addresses, Collections.emptyList());
     List<ImapAddress> result1 = EnvelopeParser.emailAddressesFromStringList(addresses1, Collections.emptyList());
     List<ImapAddress> result2 = EnvelopeParser.emailAddressesFromStringList(addresses2, Collections.emptyList());

--- a/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParseTest.java
+++ b/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParseTest.java
@@ -4,7 +4,9 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import org.apache.james.mime4j.dom.Header;
 import org.apache.james.mime4j.dom.address.Mailbox;
@@ -13,7 +15,9 @@ import org.apache.james.mime4j.message.HeaderImpl;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.Lists;
 import com.hubspot.imap.protocol.message.Envelope;
+import com.hubspot.imap.protocol.message.ImapAddress;
 import com.hubspot.imap.utils.SoftReferencedAppendableCharSequence;
 import com.hubspot.imap.utils.parsers.NestedArrayParser.Recycler;
 import com.hubspot.imap.utils.parsers.fetch.EnvelopeParser;
@@ -78,5 +82,20 @@ public class EnvelopeParseTest {
     Envelope envelope = EnvelopeParser.parseHeader(header);
     assertThat(envelope.getInReplyTo()).isNullOrEmpty();
     assertThat(envelope.getMessageId()).isNotEmpty();
+  }
+
+  @Test
+  public void testAddressParsing() throws Exception {
+    ImapAddress brian = new ImapAddress.Builder().setPersonal("Brian Cox").setAddress("brian@test.com");
+    ImapAddress bill = new ImapAddress.Builder().setPersonal("Bill").setAddress("bill@test.com");
+    ImapAddress bob = new ImapAddress.Builder().setPersonal("Bob Cox").setAddress("bob@test.com");
+    ImapAddress unknown = new ImapAddress.Builder().setAddress("unknown@test.com");
+
+    List<ImapAddress> addressList = Lists.newArrayList(brian, bill, bob, unknown);
+
+    String addresses = "bcox, Brian Cox <brian@test.com>, Cox, Bill <bill@test.com>, Bob Cox <bob@test.com>, unknown@test.com";
+
+    List<ImapAddress> result = EnvelopeParser.emailAddressesFromStringList(addresses, Collections.emptyList());
+    assertThat(result).containsOnlyElementsOf(addressList);
   }
 }

--- a/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParseTest.java
+++ b/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParseTest.java
@@ -86,16 +86,26 @@ public class EnvelopeParseTest {
 
   @Test
   public void testAddressParsing() throws Exception {
-    ImapAddress brian = new ImapAddress.Builder().setPersonal("Brian Cox").setAddress("brian@test.com");
-    ImapAddress bill = new ImapAddress.Builder().setPersonal("Bill").setAddress("bill@test.com");
-    ImapAddress bob = new ImapAddress.Builder().setPersonal("Bob Cox").setAddress("bob@test.com");
-    ImapAddress unknown = new ImapAddress.Builder().setAddress("unknown@test.com");
+    ImapAddress brianWithPersonal = new ImapAddress.Builder().setPersonal("bcox, Brian Cox").setAddress("brian@test.com");
+    ImapAddress billWithPersonal = new ImapAddress.Builder().setPersonal("Cox, Bill").setAddress("bill@test.com");
+    ImapAddress bobWithPersonal = new ImapAddress.Builder().setPersonal("Bob Cox").setAddress("bob@test.com");
+    ImapAddress brian = new ImapAddress.Builder().setAddress("brian@test.com");
+    ImapAddress bill = new ImapAddress.Builder().setAddress("bill@test.com");
+    ImapAddress bob = new ImapAddress.Builder().setAddress("bob@test.com");
 
-    List<ImapAddress> addressList = Lists.newArrayList(brian, bill, bob, unknown);
+    List<ImapAddress> addressListWithPersonal = Lists.newArrayList(brianWithPersonal, billWithPersonal, bobWithPersonal);
+    List<ImapAddress> addressList = Lists.newArrayList(brian, bill, bob);
 
-    String addresses = "bcox, Brian Cox <brian@test.com>, Cox, Bill <bill@test.com>, Bob Cox <bob@test.com>, unknown@test.com";
+    String addresses = "bcox, Brian Cox <brian@test.com>, Cox, Bill <bill@test.com>, Bob Cox <bob@test.com>";
+    String addresses1 = "brian@test.com, bill@test.com, bob@test.com";
+    String addresses2 = "<brian@test.com>, <bill@test.com>, <bob@test.com>";
+
 
     List<ImapAddress> result = EnvelopeParser.emailAddressesFromStringList(addresses, Collections.emptyList());
-    assertThat(result).containsOnlyElementsOf(addressList);
+    List<ImapAddress> result1 = EnvelopeParser.emailAddressesFromStringList(addresses1, Collections.emptyList());
+    List<ImapAddress> result2 = EnvelopeParser.emailAddressesFromStringList(addresses2, Collections.emptyList());
+    assertThat(result).containsOnlyElementsOf(addressListWithPersonal);
+    assertThat(result1).containsOnlyElementsOf(addressList);
+    assertThat(result2).containsOnlyElementsOf(addressList);
   }
 }


### PR DESCRIPTION
Legal IMAP headers can have address lists in the form of:
`"personal <email>, personal1 <email1>, personal2 <email2>"`
`"<email>, <email1>, <email2>"`
`"email, email1, email2"`

This PR aims to handle any of these legal formats of addresses.