### PR TITLE
Log Append Command Failures Better

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/command/AppendCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/AppendCommand.java
@@ -66,8 +66,12 @@ public class AppendCommand extends ContinuableCommand<TaggedResponse> {
 
   @Override
   public CompletableFuture<TaggedResponse> continueAfterResponse(ImapResponse imapResponse, Throwable throwable) {
-    if (throwable != null || !(imapResponse instanceof ContinuationResponse)) {
+    if (throwable != null) {
       throw new UnexpectedAppendResponseException(throwable);
+    }
+
+    if (!(imapResponse instanceof ContinuationResponse)) {
+      throw new UnexpectedAppendResponseException(imapResponse);
     }
 
     return imapClient.send(getStringLiteralCommand());

--- a/src/main/java/com/hubspot/imap/protocol/exceptions/UnexpectedAppendResponseException.java
+++ b/src/main/java/com/hubspot/imap/protocol/exceptions/UnexpectedAppendResponseException.java
@@ -1,13 +1,19 @@
 package com.hubspot.imap.protocol.exceptions;
 
+import com.hubspot.imap.protocol.response.ImapResponse;
+
 public class UnexpectedAppendResponseException extends RuntimeException {
-  private static final String MESSAGE = "Received unexpected response from APPEND request";
+  private static final String MESSAGE = "Received unexpected response from APPEND request: %s";
 
   public UnexpectedAppendResponseException() {
     super(MESSAGE);
   }
 
+  public UnexpectedAppendResponseException(ImapResponse response) {
+     super(String.format(MESSAGE, response.getMessage()));
+  }
+
   public UnexpectedAppendResponseException(Throwable throwable) {
-    super(MESSAGE, throwable);
+    super(String.format(MESSAGE, throwable.getMessage()), throwable);
   }
 }


### PR DESCRIPTION
Previously, `APPEND COMMAND` failures on the `continueAfterResponse` threw `UnexpectedAppendResponseException` with a static message and the throwable. This is fine for exceptional failures but in the case of no throwable and that the `ImapResponse` was not an instance of `ContinuationResponse` we never exposed that response message. This change will help debug this branch of failures better