### PR TITLE
Revert Revert of String Literal Support

### DIFF
--- a/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/string/AtomOrStringParser.java
@@ -1,9 +1,12 @@
 package com.hubspot.imap.utils.parsers.string;
 
+import java.nio.charset.StandardCharsets;
+
 import com.hubspot.imap.utils.SoftReferencedAppendableCharSequence;
 import com.hubspot.imap.utils.parsers.ByteBufParser;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.internal.AppendableCharSequence;
 
@@ -52,6 +55,8 @@ public class AtomOrStringParser implements ByteBufParser<String> {
       } else if (!isQuoted && (c == ')' || c == '(')) {
         buffer.readerIndex(buffer.readerIndex() - 1);
         break;
+      } else if (!isQuoted && (c == '{')) {
+        return parseLiteral(buffer, seq);
       } else {
         append(seq, c);
       }
@@ -67,6 +72,53 @@ public class AtomOrStringParser implements ByteBufParser<String> {
     return seq.toString();
   }
 
+  /**
+   * See https://tools.ietf.org/html/rfc3501.html#section-4.3
+   *
+   * String literals have the form
+   *
+   * {10}
+   * abcdefghij
+   *
+   * Where {10} represents the length of the string literal. The literal
+   * begins after any CLRF characters following the '}' character.
+   */
+  private String parseLiteral(ByteBuf buffer, AppendableCharSequence seq) {
+    int length = 0;
+
+    char c = (char) buffer.readUnsignedByte();
+    while (c != '}') {
+      if (Character.isDigit(c)) {
+        int digit = Character.digit(c, 10);
+        length = (length * 10) + digit;
+        c = (char) buffer.readUnsignedByte();
+      } else {
+        throw new DecoderException(
+            String.format("Found non-digit character %c where a digit was expected", c)
+        );
+      }
+    }
+
+    if (length > 0) {
+      //ignore crlf characters after '}'
+      c = (char) buffer.readUnsignedByte();
+      while (isCRLFCharacter(c)) {
+        c = (char) buffer.readUnsignedByte();
+      }
+
+      append(seq, c);
+      append(seq, buffer, length);
+
+      return seq.toString();
+    } else {
+      return "";
+    }
+  }
+
+  private boolean isCRLFCharacter(char c) {
+    return c == '\n' || c == '\r';
+  }
+
   private void append(AppendableCharSequence seq, char c) {
     if (size >= maxStringLength) {
       throw new TooLongFrameException("String is larger than " + maxStringLength + " bytes.");
@@ -76,4 +128,12 @@ public class AtomOrStringParser implements ByteBufParser<String> {
     seq.append(c);
   }
 
+  private void append(AppendableCharSequence seq, ByteBuf buffer, int length) {
+    if (size + length >= maxStringLength) {
+      throw new TooLongFrameException("String is larger than " + maxStringLength + " bytes.");
+    }
+
+    size += length;
+    seq.append(buffer.readCharSequence(length - 1, StandardCharsets.UTF_8));
+  }
 }

--- a/src/test/java/com/hubspot/imap/utils/parsers/AtomOrStringParserTest.java
+++ b/src/test/java/com/hubspot/imap/utils/parsers/AtomOrStringParserTest.java
@@ -21,6 +21,8 @@ public class AtomOrStringParserTest {
   private static final byte[] QUOTED_RESULT = Arrays.copyOfRange(QUOTED, 1, QUOTED.length-1);
   private static final byte[] ESCAPED_QUOTES = "\"This contains \\\"quotes\\\"\"".getBytes(StandardCharsets.UTF_8);
   private static final byte[] ESCAPED_QUOTES_RESULT = Arrays.copyOfRange(ESCAPED_QUOTES, 1, ESCAPED_QUOTES.length - 1);
+  private static final byte[] LITERAL = "{10}\nabcdefghij".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] LITERAL_RESULT = "abcdefghij".getBytes(StandardCharsets.UTF_8);
 
   @Test
   public void testGivenUnquotedString_doesReturnWholeString() throws Exception {
@@ -38,5 +40,11 @@ public class AtomOrStringParserTest {
   public void testGivenStringWithEscapedQuotesQuotedString_doesReturnStringWithoutSurroundingQuotes() throws Exception {
     String result = PARSER.parse(wrappedBuffer(ESCAPED_QUOTES));
     assertThat(result.getBytes(StandardCharsets.UTF_8)).isEqualTo(ESCAPED_QUOTES_RESULT);
+  }
+
+  @Test
+  public void testGivenStringWithLiteral_doesReturnLiteralWithCorrectLength() throws Exception {
+    String result = PARSER.parse(wrappedBuffer(LITERAL));
+    assertThat(result.getBytes(StandardCharsets.UTF_8)).isEqualTo(LITERAL_RESULT);
   }
 }


### PR DESCRIPTION
This PR is a revert of https://github.com/HubSpot/NioImapClient/pull/56, which is a revert of my original string literal support pr https://github.com/HubSpot/NioImapClient/pull/53.

After merging and deploying the original pr, we noticed issues with the client that were caused by issues unrelated to these changes and incorrectly concluded that it was these changes that caused the problem.