### PR TITLE
Use correct Date format for append

### DIFF
--- a/src/main/java/com/hubspot/imap/protocol/command/AppendCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/AppendCommand.java
@@ -1,6 +1,6 @@
 package com.hubspot.imap.protocol.command;
 
-import static com.hubspot.imap.utils.formats.ImapDateFormat.INTERNALDATE_FORMATTER;
+import static com.hubspot.imap.utils.formats.ImapDateFormat.IMAP_FULL_DATE_FORMAT;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -52,7 +52,7 @@ public class AppendCommand extends ContinuableCommand<TaggedResponse> {
     }
 
     if (dateTime.isPresent()) {
-      args.add(GmailUtils.quote(dateTime.get().format(INTERNALDATE_FORMATTER)));
+      args.add(GmailUtils.quote(dateTime.get().format(IMAP_FULL_DATE_FORMAT)));
     }
 
     args.add(String.format("{%d}", stringLiteralCommand.getSize()));

--- a/src/main/java/com/hubspot/imap/utils/formats/ImapDateFormat.java
+++ b/src/main/java/com/hubspot/imap/utils/formats/ImapDateFormat.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import com.google.common.collect.ImmutableSet;
 
 public class ImapDateFormat {
-  private static final DateTimeFormatter IMAP_FULL_DATE_FORMAT =
+  public static final DateTimeFormatter IMAP_FULL_DATE_FORMAT =
     new DateTimeFormatterBuilder()
       .appendPattern("dd-MMM-yyyy ")
       .appendPattern("HH:mm:ss ")


### PR DESCRIPTION
When using the APPEND command, one of the arguments is the internal date of the message we are appending. When we parse internal dates that are sent to us, we use the `d-MMM-yyyy HH:mm:ss Z` format because it will capture dates that are sent to us like "9-Apr-2018 18:08:15 +0000" as well as "09-Apr-2018 18:08:15 +0000". We did this to be as flexible as possible and give a little forgiveness to email providers who didn't correctly implement the RFC. It was incorrect to use this format for APPEND'ing messages though because email providers who are not flexible like us and are only parsing for `dd-MMM-yyyy HH:mm:ss Z` will fail to capture any date we send with a single digit day.

By making our APPENDs write out the `dd-MMM-yyyy HH:mm:ss Z` format, our command should be accepted by any RFC 3501 implemented email provider. 