### PR TITLE
Log when we received a non-OK NoopResponse

### DIFF
--- a/src/main/java/com/hubspot/imap/client/ImapClient.java
+++ b/src/main/java/com/hubspot/imap/client/ImapClient.java
@@ -460,9 +460,14 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
       if (!connectionShutdown.get()) {
         CompletableFuture<NoopResponse> noopResponse = noop();
         noopResponse.whenComplete((resp, throwable) -> {
-          if (!resp.getCode().equals(ResponseCode.OK) && channel.isOpen()) {
-            //closeNow();
-            logger.debug("Not OK response from NOOP: {}", resp.toString());
+          if (channel.isOpen()) {
+            if (throwable != null) {
+              logger.debug("Exception from NOOP", throwable);
+              //closeNow();
+            } else if (!resp.getCode().equals(ResponseCode.OK)) {
+              logger.debug("Not OK response from NOOP: {}", resp.toString());
+              //closeNow();
+            }
           }
         });
       }

--- a/src/main/java/com/hubspot/imap/client/ImapClient.java
+++ b/src/main/java/com/hubspot/imap/client/ImapClient.java
@@ -462,10 +462,10 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
         noopResponse.whenComplete((resp, throwable) -> {
           if (channel.isOpen()) {
             if (throwable != null) {
-              logger.debug("Exception from NOOP", throwable);
+              logger.warn("Exception from NOOP", throwable);
               //closeNow();
             } else if (!resp.getCode().equals(ResponseCode.OK)) {
-              logger.debug("Not OK response from NOOP: {}", resp.toString());
+              logger.warn("Not OK response from NOOP: {}", resp.toString());
               //closeNow();
             }
           }


### PR DESCRIPTION
The goal is to detect when we have lost connection to the client earlier than we do now. We poll the inbox every 15 seconds with a NOOP command and should receive a non-exceptional OK response. If we don't receive that response, we should probably disconnect and reconnect the client. For now we will just log to make sure this accurately detects problems with a connection 