### PR TITLE
Add socket timeout to Channel

### DIFF
--- a/src/main/java/com/hubspot/imap/ImapClientFactory.java
+++ b/src/main/java/com/hubspot/imap/ImapClientFactory.java
@@ -72,6 +72,7 @@ public class ImapClientFactory implements Closeable {
     Bootstrap bootstrap = new Bootstrap().group(configuration.eventLoopGroup())
         .option(ChannelOption.SO_LINGER, clientConfiguration.soLinger())
         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, clientConfiguration.connectTimeoutMillis())
+        .option(ChannelOption.SO_TIMEOUT, clientConfiguration.socketTimeoutMs())
         .option(ChannelOption.SO_KEEPALIVE, false)
         .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
         .channel(configuration.channelClass())


### PR DESCRIPTION
This is an attempt to potentially close out a file descriptor leak caused by us not having a timeout on the channel for socket reads. This could result in a hanging server causing us to cancel the calling future without actually closing the resource. Trying that action over and over again could lead to tons of unclosed file descriptors.