### PR TITLE
Ensure listeners operate asynchronously from netty event loop

### DIFF
--- a/src/main/java/com/hubspot/imap/client/ImapClient.java
+++ b/src/main/java/com/hubspot/imap/client/ImapClient.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,6 +24,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.hubspot.imap.ImapChannelAttrs;
 import com.hubspot.imap.ImapClientConfiguration;
+import com.hubspot.imap.client.listener.ListenerReference;
 import com.hubspot.imap.protocol.ResponseDecoder;
 import com.hubspot.imap.protocol.capabilities.AuthMechanism;
 import com.hubspot.imap.protocol.capabilities.Capabilities;
@@ -267,29 +269,61 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
     return send(new FetchCommand(startId, stopId, fetchItems));
   }
 
+  @Deprecated
   public <R> CompletableFuture<StreamingFetchResponse<R>> uidfetch(long startId,
                                                                    Optional<Long> stopId,
                                                                    Function<ImapMessage, R> messageFunction,
                                                                    FetchDataItem item,
                                                                    FetchDataItem... otherItems) {
-    return send(new UidCommand(ImapCommandType.FETCH, new StreamingFetchCommand<>(startId, stopId, messageFunction, item, otherItems)));
+    return send(new UidCommand(ImapCommandType.FETCH, new StreamingFetchCommand<>(startId, stopId, listener(messageFunction), item, otherItems)));
   }
 
+  public <R> CompletableFuture<StreamingFetchResponse<R>> uidfetch(long startId,
+                                                                   Optional<Long> stopId,
+                                                                   Function<ImapMessage, R> messageFunction,
+                                                                   ExecutorService executorService,
+                                                                   FetchDataItem item,
+                                                                   FetchDataItem... otherItems) {
+    return send(new UidCommand(ImapCommandType.FETCH, new StreamingFetchCommand<>(startId, stopId, listener(messageFunction, executorService), item, otherItems)));
+  }
+
+  @Deprecated
   public <R> CompletableFuture<StreamingFetchResponse<R>> fetch(long startId,
                                                                 Optional<Long> stopId,
                                                                 Function<ImapMessage, R> messageFunction,
                                                                 FetchDataItem item,
                                                                 FetchDataItem... otherItems) {
-    return send(new StreamingFetchCommand<>(startId, stopId, messageFunction, item, otherItems));
+    return send(new StreamingFetchCommand<>(startId, stopId, listener(messageFunction), item, otherItems));
   }
 
   public <R> CompletableFuture<StreamingFetchResponse<R>> fetch(long startId,
                                                                 Optional<Long> stopId,
                                                                 Function<ImapMessage, R> messageFunction,
+                                                                ExecutorService executorService,
+                                                                FetchDataItem item,
+                                                                FetchDataItem... otherItems) {
+    return send(new StreamingFetchCommand<>(startId, stopId, listener(messageFunction, executorService), item, otherItems));
+  }
+
+  @Deprecated
+  public <R> CompletableFuture<StreamingFetchResponse<R>> fetch(long startId,
+                                                                Optional<Long> stopId,
+                                                                Function<ImapMessage, R> messageFunction,
                                                                 List<FetchDataItem> fetchDataItems) {
     Preconditions.checkArgument(fetchDataItems.size() > 0, "Must have at least one FETCH item.");
-    return send(new StreamingFetchCommand<>(startId, stopId, messageFunction, fetchDataItems));
+    return send(new StreamingFetchCommand<>(startId, stopId, listener(messageFunction), fetchDataItems));
   }
+
+
+  public <R> CompletableFuture<StreamingFetchResponse<R>> fetch(long startId,
+                                                                Optional<Long> stopId,
+                                                                Function<ImapMessage, R> messageFunction,
+                                                                ExecutorService executorService,
+                                                                List<FetchDataItem> fetchDataItems) {
+    Preconditions.checkArgument(fetchDataItems.size() > 0, "Must have at least one FETCH item.");
+    return send(new StreamingFetchCommand<>(startId, stopId, listener(messageFunction, executorService), fetchDataItems));
+  }
+
 
   public CompletableFuture<FetchResponse> uidfetch(long startId,
                                                    Optional<Long> stopId,
@@ -313,12 +347,22 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
     return send(new UidCommand(ImapCommandType.FETCH, new FetchCommand(startId, stopId, fetchItems)));
   }
 
+  @Deprecated
   public <R> CompletableFuture<StreamingFetchResponse<R>> uidfetch(long startId,
                                                                    Optional<Long> stopId,
                                                                    Function<ImapMessage, R> messageFunction,
                                                                    List<FetchDataItem> fetchDataItems) {
     Preconditions.checkArgument(fetchDataItems.size() > 0, "Must have at least one FETCH item.");
-    return send(new UidCommand(ImapCommandType.FETCH, new StreamingFetchCommand<>(startId, stopId, messageFunction, fetchDataItems)));
+    return send(new UidCommand(ImapCommandType.FETCH, new StreamingFetchCommand<>(startId, stopId, listener(messageFunction), fetchDataItems)));
+  }
+
+  public <R> CompletableFuture<StreamingFetchResponse<R>> uidfetch(long startId,
+                                                                   Optional<Long> stopId,
+                                                                   Function<ImapMessage, R> messageFunction,
+                                                                   ExecutorService executorService,
+                                                                   List<FetchDataItem> fetchDataItems) {
+    Preconditions.checkArgument(fetchDataItems.size() > 0, "Must have at least one FETCH item.");
+    return send(new UidCommand(ImapCommandType.FETCH, new StreamingFetchCommand<>(startId, stopId, listener(messageFunction, executorService), fetchDataItems)));
   }
 
   public CompletableFuture<TaggedResponse> uidstore(StoreAction action,
@@ -574,6 +618,14 @@ public class ImapClient extends ChannelDuplexHandler implements AutoCloseable, C
 
   public ImapClientConfiguration getConfiguration() {
     return configuration;
+  }
+
+  private <R> ListenerReference<Function<ImapMessage, R>> listener(Function<ImapMessage, R> messageFunction) {
+    return new ListenerReference<>(messageFunction, promiseExecutor);
+  }
+
+  private <R> ListenerReference<Function<ImapMessage, R>> listener(Function<ImapMessage, R> messageFunction, ExecutorService executorService) {
+    return new ListenerReference<>(messageFunction, executorService);
   }
 
   private static final class PendingCommand {

--- a/src/main/java/com/hubspot/imap/client/ImapClientState.java
+++ b/src/main/java/com/hubspot/imap/client/ImapClientState.java
@@ -2,12 +2,15 @@ package com.hubspot.imap.client;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import com.hubspot.imap.client.listener.ConnectionListener;
+import com.hubspot.imap.client.listener.ListenerReference;
 import com.hubspot.imap.client.listener.MessageAddConsumer;
 import com.hubspot.imap.protocol.command.ImapCommand;
 import com.hubspot.imap.protocol.response.events.ExistsEvent;
@@ -29,8 +32,8 @@ public class ImapClientState extends ChannelInboundHandlerAdapter {
   private final AtomicLong commandCount;
   private final AtomicLong messageNumber;
 
-  private final List<MessageAddConsumer> messageAddListeners;
-  private final List<Consumer<OpenEvent>> openEventListeners;
+  private final List<ListenerReference<MessageAddConsumer>> messageAddListeners;
+  private final List<ListenerReference<Consumer<OpenEvent>>> openEventListeners;
   private final List<ConnectionListener> connectionListeners;
   private final List<ChannelHandler> handlers;
 
@@ -68,8 +71,9 @@ public class ImapClientState extends ChannelInboundHandlerAdapter {
       long lastMessageCount = messageNumber.getAndSet(exists.getValue());
       long currentCount = messageNumber.get();
       if (currentCount > lastMessageCount) {
-        for (BiConsumer<Long, Long> listener: messageAddListeners) {
-          executorGroup.submit(() -> listener.accept(lastMessageCount, currentCount));
+        for (ListenerReference<MessageAddConsumer> listenerReference: messageAddListeners) {
+          MessageAddConsumer listener = listenerReference.getListener();
+          listenerReference.getExecutorService().submit(() -> listener.accept(lastMessageCount, currentCount));
         }
       }
     } else if (evt instanceof OpenEvent) {
@@ -77,20 +81,30 @@ public class ImapClientState extends ChannelInboundHandlerAdapter {
       OpenResponse response = event.getOpenResponse();
       messageNumber.set(response.getExists());
 
-      for (Consumer<OpenEvent> listener: openEventListeners) {
-        executorGroup.submit(() -> listener.accept(event));
+      for (ListenerReference<Consumer<OpenEvent>> listenerReference : openEventListeners) {
+        listenerReference.getExecutorService().submit(() -> listenerReference.getListener().accept(event));
       }
     }
 
     super.userEventTriggered(ctx, evt);
   }
 
+  @Deprecated
   public void onMessageAdd(MessageAddConsumer consumer) {
-    this.messageAddListeners.add(consumer);
+    this.messageAddListeners.add(new ListenerReference<>(consumer, executorGroup));
   }
 
+  public void onMessageAdd(MessageAddConsumer consumer, ExecutorService executorService) {
+    this.messageAddListeners.add(new ListenerReference<>(consumer, executorService));
+  }
+
+  @Deprecated
   public void addOpenEventListener(Consumer<OpenEvent> consumer) {
-    this.openEventListeners.add(consumer);
+    this.openEventListeners.add(new ListenerReference<>(consumer, executorGroup));
+  }
+
+  public void addOpenEventListener(Consumer<OpenEvent> consumer, ExecutorService executorService) {
+    this.openEventListeners.add(new ListenerReference<>(consumer, executorService));
   }
 
   public void addHandler(ChannelHandler handler) {

--- a/src/main/java/com/hubspot/imap/client/listener/ListenerReference.java
+++ b/src/main/java/com/hubspot/imap/client/listener/ListenerReference.java
@@ -1,0 +1,21 @@
+package com.hubspot.imap.client.listener;
+
+import java.util.concurrent.ExecutorService;
+
+public class ListenerReference<T> {
+  private final T listener;
+  private final ExecutorService executorService;
+
+  public ListenerReference(T listener, ExecutorService executorService) {
+    this.listener = listener;
+    this.executorService = executorService;
+  }
+
+  public ExecutorService getExecutorService() {
+    return executorService;
+  }
+
+  public T getListener() {
+    return listener;
+  }
+}

--- a/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
+++ b/src/main/java/com/hubspot/imap/protocol/ResponseDecoder.java
@@ -349,7 +349,7 @@ public class ResponseDecoder extends ReplayingDecoder<State> {
         fetchCommand = ((StreamingFetchCommand) clientState.getCurrentCommand());
       }
 
-      CompletableFuture<?> future = CompletableFuture.supplyAsync(() -> fetchCommand.handle(message), executorGroup);
+      CompletableFuture<?> future = fetchCommand.invokeListener(message);
 
       untaggedResponses.add(future);
     } else {

--- a/src/main/java/com/hubspot/imap/protocol/command/fetch/StreamingFetchCommand.java
+++ b/src/main/java/com/hubspot/imap/protocol/command/fetch/StreamingFetchCommand.java
@@ -2,27 +2,31 @@ package com.hubspot.imap.protocol.command.fetch;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 import com.google.common.collect.Lists;
+import com.hubspot.imap.client.listener.ListenerReference;
 import com.hubspot.imap.protocol.command.fetch.items.FetchDataItem;
 import com.hubspot.imap.protocol.message.ImapMessage;
 
 public class StreamingFetchCommand<R> extends FetchCommand {
 
-  private final Function<ImapMessage, R> messageConsumer;
+  private final ListenerReference<Function<ImapMessage, R>> messageConsumer;
 
-  public StreamingFetchCommand(long startId, Optional<Long> stopId, Function<ImapMessage, R> messageConsumer, List<FetchDataItem> fetchDataItems) {
+  public StreamingFetchCommand(long startId, Optional<Long> stopId, ListenerReference<Function<ImapMessage, R>> messageConsumer, List<FetchDataItem> fetchDataItems) {
     super(startId, stopId, fetchDataItems);
 
     this.messageConsumer = messageConsumer;
   }
 
-  public StreamingFetchCommand(long startId, Optional<Long> stopId, Function<ImapMessage, R> messageConsumer, FetchDataItem item, FetchDataItem... otherItems) {
+  public StreamingFetchCommand(long startId, Optional<Long> stopId, ListenerReference<Function<ImapMessage, R>> messageConsumer, FetchDataItem item, FetchDataItem... otherItems) {
     this(startId, stopId, messageConsumer, Lists.asList(item, otherItems));
   }
 
-  public R handle(ImapMessage message) {
-    return messageConsumer.apply(message);
+  public CompletableFuture<?> invokeListener(ImapMessage message) {
+    return CompletableFuture.supplyAsync(() ->
+        messageConsumer.getListener().apply(message), messageConsumer.getExecutorService());
   }
 }

--- a/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
+++ b/src/test/java/com/hubspot/imap/BaseGreenMailServerTest.java
@@ -32,6 +32,7 @@ public class BaseGreenMailServerTest {
         .useSsl(false)
         .connectTimeoutMillis(1000)
         .tracingEnabled(true)
+        .noopKeepAliveIntervalSec(1)
         .build();
   }
 

--- a/src/test/java/com/hubspot/imap/ConnectionFailureTest.java
+++ b/src/test/java/com/hubspot/imap/ConnectionFailureTest.java
@@ -7,9 +7,11 @@ import org.junit.Test;
 import com.google.common.net.HostAndPort;
 
 public class ConnectionFailureTest extends BaseGreenMailServerTest {
+  private static final int LIKELY_UNUSED_PORT_NUMBER = 10050; // sourced from https://svn.nmap.org/nmap/nmap-services
+
   @Test
   public void testGivenBadHost_doesThrowOnConnect() throws Exception {
-    getClientFactory().connect(getImapConfig().withHostAndPort(HostAndPort.fromParts("localhost", 12345)))
+    getClientFactory().connect(getImapConfig().withHostAndPort(HostAndPort.fromParts("localhost", LIKELY_UNUSED_PORT_NUMBER)))
         .handle((imapClient, throwable) -> {
           assertThat(throwable).isNotNull();
           return null;

--- a/src/test/java/com/hubspot/imap/MessageAddListenerTest.java
+++ b/src/test/java/com/hubspot/imap/MessageAddListenerTest.java
@@ -19,7 +19,7 @@ import com.hubspot.imap.protocol.response.tagged.OpenResponse;
 
 /***
  * @implNote Greenmail doesn't appear to support the EXISTS untagged response so we can't test
- * when MessageAddListeners completely.
+ * when MessageAddListeners fire completely.
  */
 public class MessageAddListenerTest extends BaseGreenMailServerTest {
 

--- a/src/test/java/com/hubspot/imap/StreamingFetchCommandTest.java
+++ b/src/test/java/com/hubspot/imap/StreamingFetchCommandTest.java
@@ -1,0 +1,67 @@
+package com.hubspot.imap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.imap.client.FolderOpenMode;
+import com.hubspot.imap.client.ImapClient;
+import com.hubspot.imap.protocol.command.fetch.items.FetchDataItem.FetchDataItemType;
+import com.hubspot.imap.protocol.response.ResponseCode;
+import com.hubspot.imap.protocol.response.tagged.OpenResponse;
+import com.hubspot.imap.protocol.response.tagged.StreamingFetchResponse;
+
+public class StreamingFetchCommandTest extends BaseGreenMailServerTest {
+
+  private ImapClient client;
+  private ExecutorService executorService;
+  private long uidNext;
+
+  @After
+  public void cleanup() throws Exception {
+    client.close();
+  }
+
+  @Before
+  public void initialize() throws Exception {
+    super.setUp();
+    client = getLoggedInClient();
+    deliverRandomMessage();
+    CompletableFuture<OpenResponse> openFuture = client.open(DEFAULT_FOLDER, FolderOpenMode.READ);
+    uidNext = openFuture.get(30, TimeUnit.SECONDS).getUidNext();
+
+    executorService = Executors.newSingleThreadExecutor();
+  }
+
+  @Test
+  public void testOnFetch_ItCallsBackStreamingMethod() throws Exception {
+    CountDownLatch countDownLatch = new CountDownLatch(1);
+
+    CompletableFuture<StreamingFetchResponse<Void>> fetchFuture = client.uidfetch(
+        uidNext,
+        Optional.empty(),
+        (imapMessage) -> {
+          countDownLatch.countDown();
+          return null;
+        },
+        executorService,
+        FetchDataItemType.ENVELOPE);
+    fetchFuture.get(10, TimeUnit.SECONDS);
+    assertThat(fetchFuture.isDone()).isTrue();
+    assertThat(fetchFuture.isCompletedExceptionally()).isFalse();
+    assertThat(fetchFuture.get().getCode()).isEqualTo(ResponseCode.OK);
+
+    assertThat(countDownLatch.await(1, TimeUnit.SECONDS)).isTrue();
+  }
+}


### PR DESCRIPTION
This PR ensures that most of the listener/callback mechanisms operate on a separate ExecutionService, so that they don't clog up the main netty event loop threads.