### PR TITLE
Add socks proxy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,21 +4,11 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.3</version>
+    <version>25.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>NioImapClient</artifactId>
   <version>0.5-SNAPSHOT</version>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>2.0.18</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/src/main/java/com/hubspot/imap/ImapChannelInitializer.java
+++ b/src/main/java/com/hubspot/imap/ImapChannelInitializer.java
@@ -1,12 +1,16 @@
 package com.hubspot.imap;
 
+import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
+
+import com.google.common.net.HostAndPort;
 
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringEncoder;
+import io.netty.handler.proxy.Socks4ProxyHandler;
 import io.netty.handler.ssl.SslContext;
 
 @Sharable
@@ -28,6 +32,12 @@ public class ImapChannelInitializer extends ChannelInitializer<SocketChannel> {
   @Override
   protected void initChannel(SocketChannel socketChannel) throws Exception {
     ChannelPipeline channelPipeline = socketChannel.pipeline();
+
+    if (configuration.socksProxyConfig().isPresent()) {
+      HostAndPort proxyHost = configuration.socksProxyConfig().get().proxyHost();
+      channelPipeline.addFirst(new Socks4ProxyHandler(
+          new InetSocketAddress(proxyHost.getHost(), proxyHost.getPort())));
+    }
 
     if (sslContext != null) {
       channelPipeline.addLast(sslContext.newHandler(socketChannel.alloc(),

--- a/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
+++ b/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
@@ -102,6 +102,9 @@ public interface ImapClientConfigurationIF {
   }
 
   @Default
+  default Optional<SocksProxyConfig> socksProxyConfig() { return Optional.empty(); }
+
+  @Default
   default List<AuthMechanism> allowedAuthMechanisms() {
     return ConfigDefaults.DEFAULT_ALLOWED_AUTH_MECHANISMS;
   }

--- a/src/main/java/com/hubspot/imap/SocksProxyConfigIF.java
+++ b/src/main/java/com/hubspot/imap/SocksProxyConfigIF.java
@@ -1,0 +1,19 @@
+package com.hubspot.imap;
+
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.net.HostAndPort;
+
+@Immutable
+@Style(
+    typeAbstract = {"*IF"},
+    typeImmutable = "*"
+)
+@JsonDeserialize(as = SocksProxyConfig.class)
+@JsonSerialize(as = SocksProxyConfig.class)
+public interface SocksProxyConfigIF {
+  HostAndPort proxyHost();
+}


### PR DESCRIPTION
The current proxy mechanism in NioImapClient is based on a non-standard "PROXY" ASCII command that is not supported in the community.  This PR adds socks proxies support.  While I could've written an integration test that used an in-memory netty-based socks proxy, I instead opted to test the whole suite of tests with a socks proxy by manually adding the socks proxy config and running a local socks proxy server via `ssh -v -C -N -D localhost:1080 localhost`.  Also, I couldn't locate any nice plug-and-play socks proxy from the java community to use in testing.