### PR TITLE
Use basepom-release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.8-SNAPSHOT</version>
+    <version>25.8</version>
   </parent>
 
   <artifactId>NioImapClient</artifactId>


### PR DESCRIPTION
25.8 is released now so we don't need to use a snapshot