### PR TITLE
upgrade netty to 4.1.110

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.9</version>
+    <version>59.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>NioImapClient</artifactId>
@@ -50,8 +50,7 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <classifier>${dep.netty.epoll.classifier}</classifier>
+      <artifactId>netty-transport-classes-epoll</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -181,19 +180,4 @@
     <url>git@github.com:HubSpot/NioImapClient.git</url>
     <tag>HEAD</tag>
   </scm>
-
-  <profiles>
-    <profile>
-      <id>linux</id>
-      <activation>
-        <os>
-          <name>Linux</name>
-          <family>unix</family>
-        </os>
-      </activation>
-      <properties>
-        <dep.netty.epoll.classifier>${os.detected.classifier}</dep.netty.epoll.classifier>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,16 @@
       <artifactId>greenmail</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.icegreen</groupId>
+      <artifactId>greenmail-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-guava</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/com/hubspot/imap/ImapMultiServerTest.java
+++ b/src/test/java/com/hubspot/imap/ImapMultiServerTest.java
@@ -3,6 +3,7 @@ package com.hubspot.imap;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.hubspot.imap.client.ImapClient;
 import com.hubspot.imap.protocol.exceptions.ConnectionClosedException;
 import java.io.IOException;
@@ -25,12 +26,10 @@ public abstract class ImapMultiServerTest {
       .getContextClassLoader()
       .getResourceAsStream("profiles.yaml");
 
-    ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+    ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory())
+      .registerModule(new GuavaModule());
 
-    return objectMapper.readValue(
-      inputStream,
-      new TypeReference<List<TestServerConfig>>() {}
-    );
+    return objectMapper.readValue(inputStream, new TypeReference<>() {});
   }
 
   @Parameters(name = "{0}")

--- a/src/test/java/com/hubspot/imap/client/ImapClientTest.java
+++ b/src/test/java/com/hubspot/imap/client/ImapClientTest.java
@@ -579,7 +579,7 @@ public class ImapClientTest extends BaseGreenMailServerTest {
       )
       .get();
     assertThat(appendResponse.getCode()).isEqualTo(ResponseCode.OK);
-    long uid = Long.parseLong(appendResponse.getMessage().substring(25, 26));
+    long uid = Long.parseLong(appendResponse.getMessage().substring(22, 23));
 
     FetchResponse postAppendFetchAll = client
       .fetch(

--- a/src/test/resources/profiles.yaml
+++ b/src/test/resources/profiles.yaml
@@ -1,3 +1,4 @@
+[ ]
 #- host: imap.gmail.com
 #  port: 993
 #  user: hsimaptest1@gmail.com


### PR DESCRIPTION
basepom 59.10 upgrades netty from 4.1.8 to 4.1.110.

this also upgrades greenmail used in tests to 1.6, and enables TLS in tests.