### PR TITLE
Add log to collect info about imap envelope parsing issue

### DIFF
--- a/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
+++ b/src/main/java/com/hubspot/imap/utils/parsers/fetch/EnvelopeParser.java
@@ -63,6 +63,14 @@ public class EnvelopeParser {
   public static Envelope parse(List<Object> in) {
     LOGGER.debug("Parsing envelope response: {}", in);
 
+    if (in.size() < 10) {
+      LOGGER.warn(
+        "Envelope response must have at least 10 elements, but found {}. The response is: {}",
+        in.size(),
+        in
+      );
+    }
+
     String dateString = castToString(in.get(0));
     String subject = castToString(in.get(1));
 

--- a/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParserTest.java
+++ b/src/test/java/com/hubspot/imap/utils/parsers/EnvelopeParserTest.java
@@ -1,0 +1,78 @@
+package com.hubspot.imap.utils.parsers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.hubspot.imap.protocol.message.Envelope;
+import com.hubspot.imap.protocol.message.ImapAddress;
+import com.hubspot.imap.utils.parsers.fetch.EnvelopeParser;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class EnvelopeParserTest {
+
+  @Test
+  public void testParseWithAllElements() {
+    List<Object> envelopeResponse = Arrays.asList(
+      "Tue, 21 Jul 2015 16:02:13 EDT", // date
+      "Test Subject", // subject
+      Arrays.asList(List.of("John Doe", "smtp", "john.doe", "example.com")), // from
+      Arrays.asList(List.of("Jane Doe", "smtp", "jane.doe", "example.com")), // sender
+      Arrays.asList(List.of("Reply To", "smtp", "reply.to", "example.com")), // reply-to
+      Arrays.asList(List.of("Recipient", "smtp", "recipient", "example.com")), // to
+      Arrays.asList(List.of("CC", "smtp", "cc", "example.com")), // cc
+      Arrays.asList(List.of("BCC", "smtp", "bcc", "example.com")), // bcc
+      "In-Reply-To", // in-reply-to
+      "Message-ID" // message-id
+    );
+
+    Envelope envelope = EnvelopeParser.parse(envelopeResponse);
+
+    assertThat(envelope.getDateString()).isEqualTo("Tue, 21 Jul 2015 16:02:13 EDT");
+    assertThat(envelope.getSubject()).isEqualTo("Test Subject");
+    assertThat(envelope.getFrom())
+      .extracting(ImapAddress::getAddress)
+      .containsExactly("john.doe@example.com");
+    assertThat(envelope.getSender())
+      .extracting(ImapAddress::getAddress)
+      .containsExactly("jane.doe@example.com");
+    assertThat(envelope.getReplyTo())
+      .extracting(ImapAddress::getAddress)
+      .containsExactly("reply.to@example.com");
+    assertThat(envelope.getTo())
+      .extracting(ImapAddress::getAddress)
+      .containsExactly("recipient@example.com");
+    assertThat(envelope.getCc())
+      .extracting(ImapAddress::getAddress)
+      .containsExactly("cc@example.com");
+    assertThat(envelope.getBcc())
+      .extracting(ImapAddress::getAddress)
+      .containsExactly("bcc@example.com");
+    assertThat(envelope.getInReplyTo()).isEqualTo("In-Reply-To");
+    assertThat(envelope.getMessageId()).isEqualTo("Message-ID");
+  }
+
+  @Test
+  public void testParseWithOnly9Elements() {
+    List<Object> envelopeResponse = Arrays.asList(
+      "Tue, 21 Jul 2015 16:02:13 EDT", // date
+      "Test Subject", // subject
+      Arrays.asList(List.of("John Doe", "smtp", "john.doe", "example.com")), // from
+      Arrays.asList(List.of("Jane Doe", "smtp", "jane.doe", "example.com")), // sender
+      Arrays.asList(List.of("Reply To", "smtp", "reply.to", "example.com")), // reply-to
+      Arrays.asList(List.of("Recipient", "smtp", "recipient", "example.com")), // to
+      Arrays.asList(List.of("CC", "smtp", "cc", "example.com")), // cc
+      Arrays.asList(List.of("BCC", "smtp", "bcc", "example.com")), // bcc
+      // missing in-reply-to
+      "Message-ID" // message-id
+    );
+
+    assertThrows(
+      ArrayIndexOutOfBoundsException.class,
+      () -> {
+        EnvelopeParser.parse(envelopeResponse);
+      }
+    );
+  }
+}


### PR DESCRIPTION
We got a lot of error like this 
```
Caused by: java.lang.IndexOutOfBoundsException: Index 9 out of bounds for length 9
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at com.hubspot.imap.utils.parsers.fetch.EnvelopeParser.parse(EnvelopeParser.java:77)
	at com.hubspot.imap.protocol.ResponseDecoder.parseEnvelope(ResponseDecoder.java:580)
	at com.hubspot.imap.protocol.ResponseDecoder.parseFetch(ResponseDecoder.java:328)
	at com.hubspot.imap.protocol.ResponseDecoder.decode(ResponseDecoder.java:248)
	at nettyfourone.io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:501)
	at nettyfourone.io.netty.handler.codec.ReplayingDecoder.callDecode(ReplayingDecoder.java:366)
```
apparently the server does not quite follow the RFC 3501 to have all the elements, but to collect more info, it is better to include some log when it happens. This PR purposely does not make any logic change.