### PR TITLE
allow ssl protocols to be configurable per imap connection

### DIFF
--- a/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
+++ b/src/main/java/com/hubspot/imap/ImapClientConfigurationIF.java
@@ -7,6 +7,7 @@ import com.hubspot.imap.protocol.capabilities.AuthMechanism;
 import com.hubspot.imap.utils.ConfigDefaults;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.net.ssl.TrustManagerFactory;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Derived;
@@ -34,6 +35,11 @@ public interface ImapClientConfigurationIF {
   @Default
   default boolean useSsl() {
     return true;
+  }
+
+  @Default
+  default Set<String> sslProtocols() {
+    return Set.of();
   }
 
   @Default

--- a/src/main/java/com/hubspot/imap/ImapClientFactory.java
+++ b/src/main/java/com/hubspot/imap/ImapClientFactory.java
@@ -132,10 +132,15 @@ public class ImapClientFactory implements Closeable {
       return sslContext;
     }
     try {
-      return SslContextBuilder
+      SslContextBuilder sslContextBuilder = SslContextBuilder
         .forClient()
-        .trustManager(clientConfiguration.trustManagerFactory().get())
-        .build();
+        .trustManager(clientConfiguration.trustManagerFactory().get());
+
+      if (!clientConfiguration.sslProtocols().isEmpty()) {
+        sslContextBuilder.protocols(clientConfiguration.sslProtocols());
+      }
+
+      return sslContextBuilder.build();
     } catch (SSLException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
we've found that certain imap providers fail to connect using versions of netty > 4.1.51, which updates the default SSL protocol list. this change allows us to specify an overridden set of TLS protocols per connection.
